### PR TITLE
Make sibling/adjacent selector only match following siblings (fixes #23)

### DIFF
--- a/esquery.js
+++ b/esquery.js
@@ -8,6 +8,9 @@
         return {}.toString.call(array) === '[object Array]';
     };
 
+    var LEFT_SIDE = {};
+    var RIGHT_SIDE = {};
+
     function esqueryModule() {
 
         /**
@@ -122,16 +125,16 @@
 
                 case 'sibling':
                     return matches(node, selector.right, ancestry) &&
-                        sibling(node, selector.left, ancestry, 'left') ||
+                        sibling(node, selector.left, ancestry, LEFT_SIDE) ||
                         matches(node, selector.left, ancestry) &&
-                        sibling(node, selector.right, ancestry, 'right') &&
+                        sibling(node, selector.right, ancestry, RIGHT_SIDE) &&
                         selector.left.subject;
 
                 case 'adjacent':
                     return matches(node, selector.right, ancestry) &&
-                        adjacent(node, selector.left, ancestry, 'left') ||
+                        adjacent(node, selector.left, ancestry, LEFT_SIDE) ||
                         matches(node, selector.left, ancestry) &&
-                        adjacent(node, selector.right, ancestry, 'right') &&
+                        adjacent(node, selector.right, ancestry, RIGHT_SIDE) &&
                         selector.left.subject;
 
                 case 'nth-child':
@@ -183,7 +186,7 @@
                 if (isArray(listProp)) {
                     startIndex = listProp.indexOf(node);
                     if (startIndex < 0) { continue; }
-                    if (side === 'left') {
+                    if (side === LEFT_SIDE) {
                       lowerBound = 0;
                       upperBound = startIndex;
                     } else {
@@ -212,10 +215,10 @@
                 if (isArray(listProp)) {
                     idx = listProp.indexOf(node);
                     if (idx < 0) { continue; }
-                    if (side === 'left' && idx > 0 && matches(listProp[idx - 1], selector, ancestry)) {
+                    if (side === LEFT_SIDE && idx > 0 && matches(listProp[idx - 1], selector, ancestry)) {
                         return true;
                     }
-                    if (side === 'right' && idx < listProp.length - 1 && matches(listProp[idx + 1], selector, ancestry)) {
+                    if (side === RIGHT_SIDE && idx < listProp.length - 1 && matches(listProp[idx + 1], selector, ancestry)) {
                         return true;
                     }
                 }

--- a/esquery.js
+++ b/esquery.js
@@ -126,16 +126,16 @@
                 case 'sibling':
                     return matches(node, selector.right, ancestry) &&
                         sibling(node, selector.left, ancestry, LEFT_SIDE) ||
+                        selector.left.subject &&
                         matches(node, selector.left, ancestry) &&
-                        sibling(node, selector.right, ancestry, RIGHT_SIDE) &&
-                        selector.left.subject;
+                        sibling(node, selector.right, ancestry, RIGHT_SIDE);
 
                 case 'adjacent':
                     return matches(node, selector.right, ancestry) &&
                         adjacent(node, selector.left, ancestry, LEFT_SIDE) ||
+                        selector.right.subject &&
                         matches(node, selector.left, ancestry) &&
-                        adjacent(node, selector.right, ancestry, RIGHT_SIDE) &&
-                        selector.left.subject;
+                        adjacent(node, selector.right, ancestry, RIGHT_SIDE);
 
                 case 'nth-child':
                     return matches(node, selector.right, ancestry) &&

--- a/esquery.js
+++ b/esquery.js
@@ -122,15 +122,17 @@
 
                 case 'sibling':
                     return matches(node, selector.right, ancestry) &&
-                        sibling(node, selector.left, ancestry) ||
+                        sibling(node, selector.left, ancestry, 'left') ||
                         matches(node, selector.left, ancestry) &&
-                        sibling(node, selector.right, ancestry);
+                        sibling(node, selector.right, ancestry, 'right') &&
+                        selector.left.subject;
 
                 case 'adjacent':
                     return matches(node, selector.right, ancestry) &&
-                        adjacent(node, selector.left, ancestry) ||
+                        adjacent(node, selector.left, ancestry, 'left') ||
                         matches(node, selector.left, ancestry) &&
-                        adjacent(node, selector.right, ancestry);
+                        adjacent(node, selector.right, ancestry, 'right') &&
+                        selector.left.subject;
 
                 case 'nth-child':
                     return matches(node, selector.right, ancestry) &&
@@ -172,15 +174,24 @@
         /*
          * Determines if the given node has a sibling that matches the given selector.
          */
-        function sibling(node, selector, ancestry) {
-            var parent = ancestry[0], listProp, keys, i, l, k, m;
+        function sibling(node, selector, ancestry, side) {
+            var parent = ancestry[0], listProp, startIndex, keys, i, l, k, lowerBound, upperBound;
             if (!parent) { return false; }
             keys = estraverse.VisitorKeys[parent.type];
             for (i = 0, l = keys.length; i < l; ++i) {
                 listProp = parent[keys[i]];
                 if (isArray(listProp)) {
-                    for (k = 0, m = listProp.length; k < m; ++k) {
-                        if (listProp[k] !== node && matches(listProp[k], selector, ancestry)) {
+                    startIndex = listProp.indexOf(node);
+                    if (startIndex < 0) { continue; }
+                    if (side === 'left') {
+                      lowerBound = 0;
+                      upperBound = startIndex;
+                    } else {
+                      lowerBound = startIndex + 1;
+                      upperBound = listProp.length;
+                    }
+                    for (k = lowerBound; k < upperBound; ++k) {
+                        if (matches(listProp[k], selector, ancestry)) {
                             return true;
                         }
                     }
@@ -192,7 +203,7 @@
         /*
          * Determines if the given node has an asjacent sibling that matches the given selector.
          */
-        function adjacent(node, selector, ancestry) {
+        function adjacent(node, selector, ancestry, side) {
             var parent = ancestry[0], listProp, keys, i, l, idx;
             if (!parent) { return false; }
             keys = estraverse.VisitorKeys[parent.type];
@@ -201,10 +212,10 @@
                 if (isArray(listProp)) {
                     idx = listProp.indexOf(node);
                     if (idx < 0) { continue; }
-                    if (idx > 0 && matches(listProp[idx - 1], selector, ancestry)) {
+                    if (side === 'left' && idx > 0 && matches(listProp[idx - 1], selector, ancestry)) {
                         return true;
                     }
-                    if (idx < listProp.length - 1 && matches(listProp[idx + 1], selector, ancestry)) {
+                    if (side === 'right' && idx < listProp.length - 1 && matches(listProp[idx + 1], selector, ancestry)) {
                         return true;
                     }
                 }

--- a/tests/fixtures/bigArray.js
+++ b/tests/fixtures/bigArray.js
@@ -1,0 +1,7 @@
+define(["esprima"], function (esprima) {
+
+    return esprima.parse(
+        '[1, 2, 3, foo, bar, 4, 5, baz, qux, 6]'
+    );
+
+});

--- a/tests/querySubject.js
+++ b/tests/querySubject.js
@@ -6,8 +6,9 @@ define([
     "./fixtures/forLoop",
     "./fixtures/simpleFunction",
     "./fixtures/simpleProgram",
-    "./fixtures/nestedFunctions"
-], function (esquery, assert, test, conditional, forLoop, simpleFunction, simpleProgram, nestedFunctions) {
+    "./fixtures/nestedFunctions",
+    "./fixtures/bigArray"
+], function (esquery, assert, test, conditional, forLoop, simpleFunction, simpleProgram, nestedFunctions, bigArray) {
 
     test.defineSuite("Query subject", {
 
@@ -136,6 +137,25 @@ define([
                 simpleProgram.body[1],
                 simpleProgram.body[2]
             ], matches);
+        },
+
+        "multiple adjacent siblings": function () {
+            var matches = esquery(bigArray, "Identifier + Identifier");
+            assert.contains([
+                bigArray.body[0].expression.elements[4],
+                bigArray.body[0].expression.elements[8]
+            ], matches);
+            assert.isSame(2, matches.length);
+        },
+
+        "multiple siblings": function () {
+            var matches = esquery(bigArray, "Identifier ~ Identifier");
+            assert.contains([
+                bigArray.body[0].expression.elements[4],
+                bigArray.body[0].expression.elements[7],
+                bigArray.body[0].expression.elements[8]
+            ], matches);
+            assert.isSame(3, matches.length);
         }
     });
 });


### PR DESCRIPTION
This updates the `sibling` and `adjacent` functions to only search for matches on the correct side of the given node, which solves the issue described in https://github.com/estools/esquery/issues/23.