### PR TITLE
Make :function matching more precise

### DIFF
--- a/esquery.js
+++ b/esquery.js
@@ -165,7 +165,8 @@
                                 node.type === 'Literal' ||
                                 node.type === 'Identifier';
                         case 'function':
-                            return node.type.slice(0, 8) === 'Function' ||
+                            return node.type === 'FunctionDeclaration' ||
+                                node.type === 'FunctionExpression' ||
                                 node.type === 'ArrowFunctionExpression';
                     }
                     throw new Error('Unknown class name: ' + selector.name);


### PR DESCRIPTION
To check whether a node's type is `FunctionDeclaration` or `FunctionExpression`, esquery currently checks `node.type.slice(0, 8) === "Function"` as a shorthand rather than matching the node type explicitly. This works fine for the current ESTree spec because no other node types start with `Function`, but it can lead to unexpected behavior when traversing ASTs that have other node types starting with `Function`.

esquery shouldn't need to account for the semantics of particular unknown node types, but using more precise `node.type` checks here would make esquery more robust when matching against custom/extended ASTs in general. This commit replaces the `type.startsWith("Function")` shorthand with an explicit check for `"FunctionDeclaration"` and `"FunctionExpression"`.