### PR TITLE
adjacent returns false if keys are undefined

### DIFF
--- a/esquery.js
+++ b/esquery.js
@@ -226,6 +226,7 @@
             var parent = ancestry[0], listProp, keys, i, l, idx;
             if (!parent) { return false; }
             keys = estraverse.VisitorKeys[parent.type];
+            if (!keys) { return false; }
             for (i = 0, l = keys.length; i < l; ++i) {
                 listProp = parent[keys[i]];
                 if (isArray(listProp)) {


### PR DESCRIPTION
this is a weird bug that i noticed while writing an eslint rule with the following selector

    ImportDeclaration + :not(ImportDeclaration)

for certain types of file using babel-eslint, this would throw `Cannot read property 'length' of undefined`

<details>
```
Cannot read property 'length' of undefined
TypeError: Cannot read property 'length' of undefined
    at adjacent (/Users/marcos/SpacedOut/sense/ui_server/node_modules/esquery/esquery.js:214:33)
    at Function.matches (/Users/marcos/SpacedOut/sense/ui_server/node_modules/esquery/esquery.js:135:25)
    at NodeEventGenerator.applySelector (/Users/marcos/SpacedOut/sense/ui_server/node_modules/eslint/lib/util/node-event-generator.js:264:21)
    at NodeEventGenerator.applySelectors (/Users/marcos/SpacedOut/sense/ui_server/node_modules/eslint/lib/util/node-event-generator.js:292:22)
    at NodeEventGenerator.enterNode (/Users/marcos/SpacedOut/sense/ui_server/node_modules/eslint/lib/util/node-event-generator.js:308:14)
    at CodePathAnalyzer.enterNode (/Users/marcos/SpacedOut/sense/ui_server/node_modules/eslint/lib/code-path-analysis/code-path-analyzer.js:602:23)
    at CommentEventGenerator.enterNode (/Users/marcos/SpacedOut/sense/ui_server/node_modules/eslint/lib/util/comment-event-generator.js:98:23)
    at Traverser.enter (/Users/marcos/SpacedOut/sense/ui_server/node_modules/eslint/lib/eslint.js:929:36)
    at Traverser.__execute (/Users/marcos/SpacedOut/sense/ui_server/node_modules/estraverse/estraverse.js:397:31)
    at Traverser.traverse (/Users/marcos/SpacedOut/sense/ui_server/node_modules/estraverse/estraverse.js:501:28)
```
</details>

adding this fixes my specific bug but i have to suspect that it's possible that other selectors are vulnerable to this problem. i can amend this pr to catch those cases as well if you think it's a worthwhile change.