### PR TITLE
Fix: add MetaProperty and TemplateLiteral to :expression class

### DIFF
--- a/esquery.js
+++ b/esquery.js
@@ -178,8 +178,9 @@
                             // fallthrough: interface Expression <: Node, Pattern { }
                         case 'expression':
                             return node.type.slice(-10) === 'Expression' ||
-                                node.type === 'Literal' ||
-                                node.type === 'Identifier';
+                                node.type.slice(-7) === 'Literal' ||
+                                node.type === 'Identifier' ||
+                                node.type === 'MetaProperty';
                         case 'function':
                             return node.type.slice(0, 8) === 'Function' ||
                                 node.type === 'ArrowFunctionExpression';

--- a/esquery.js
+++ b/esquery.js
@@ -179,7 +179,10 @@
                         case 'expression':
                             return node.type.slice(-10) === 'Expression' ||
                                 node.type.slice(-7) === 'Literal' ||
-                                node.type === 'Identifier' ||
+                                (
+                                    node.type === 'Identifier' &&
+                                    (ancestry.length === 0 || ancestry[0].type !== 'MetaProperty')
+                                ) ||
                                 node.type === 'MetaProperty';
                         case 'function':
                             return node.type.slice(0, 8) === 'Function' ||

--- a/tests/fixtures/allClasses.js
+++ b/tests/fixtures/allClasses.js
@@ -1,6 +1,6 @@
 define(["esprima"], function (esprima) {
 
-    // return esprima.parse("function a(){ [a] = () => 0; new.target; `test`; }");
+    // return esprima.parse("function a(){ [a] = () => 0; new.target; `test`; `hello,${name}`; }");
 
     return {
         "type": "Program",
@@ -75,6 +75,36 @@ define(["esprima"], function (esprima) {
                             ],
                             "expressions": [],
                           },
+                        },
+                        {
+                            "type": "ExpressionStatement",
+                            "expression": {
+                                "type": "TemplateLiteral",
+                                "quasis": [
+                                    {
+                                        "type": "TemplateElement",
+                                        "value": {
+                                            "raw": "hello,",
+                                            "cooked": "hello,"
+                                        },
+                                        "tail": false,
+                                    },
+                                    {
+                                        "type": "TemplateElement",
+                                        "value": {
+                                            "raw": "",
+                                            "cooked": ""
+                                        },
+                                        "tail": true,
+                                    }
+                                ],
+                                "expressions": [
+                                    {
+                                        "type": "Identifier",
+                                        "name": "name",
+                                    }
+                                ],
+                            },
                         }
                     ]
                 },

--- a/tests/fixtures/allClasses.js
+++ b/tests/fixtures/allClasses.js
@@ -1,6 +1,6 @@
 define(["esprima"], function (esprima) {
 
-    // return esprima.parse("function a(){ [a] = () => 0; }");
+    // return esprima.parse("function a(){ [a] = () => 0; new.target; `test`; }");
 
     return {
         "type": "Program",
@@ -44,6 +44,37 @@ define(["esprima"], function (esprima) {
                                     "expression": false
                                 }
                             }
+                        },
+                        {
+                          "type": "ExpressionStatement",
+                          "expression": {
+                            "type": "MetaProperty",
+                            "meta": {
+                              "type": "Identifier",
+                              "name": "new",
+                            },
+                            "property": {
+                              "type": "Identifier",
+                              "name": "target",
+                            },
+                          },
+                        },
+                        {
+                          "type": "ExpressionStatement",
+                          "expression": {
+                            "type": "TemplateLiteral",
+                            "quasis": [
+                              {
+                                "type": "TemplateElement",
+                                "value": {
+                                  "raw": "test",
+                                  "cooked": "test"
+                                },
+                                "tail": true,
+                              }
+                            ],
+                            "expressions": [],
+                          },
                         }
                     ]
                 },

--- a/tests/queryClass.js
+++ b/tests/queryClass.js
@@ -13,9 +13,11 @@ define([
             assert.contains([
               ast.body[0],
               ast.body[0].body,
-              ast.body[0].body.body[0]
+              ast.body[0].body.body[0],
+              ast.body[0].body.body[1],
+              ast.body[0].body.body[2]
             ], matches);
-            assert.isSame(3, matches.length);
+            assert.isSame(5, matches.length);
         },
 
         ":expression": function () {
@@ -25,9 +27,13 @@ define([
               ast.body[0].body.body[0].expression,
               ast.body[0].body.body[0].expression.left.elements[0],
               ast.body[0].body.body[0].expression.right,
-              ast.body[0].body.body[0].expression.right.body
+              ast.body[0].body.body[0].expression.right.body,
+              ast.body[0].body.body[1].expression,
+              ast.body[0].body.body[1].expression.meta,
+              ast.body[0].body.body[1].expression.property,
+              ast.body[0].body.body[2].expression
             ], matches);
-            assert.isSame(5, matches.length);
+            assert.isSame(9, matches.length);
         },
 
         ":function": function () {
@@ -55,9 +61,13 @@ define([
               ast.body[0].body.body[0].expression.left,
               ast.body[0].body.body[0].expression.left.elements[0],
               ast.body[0].body.body[0].expression.right,
-              ast.body[0].body.body[0].expression.right.body
+              ast.body[0].body.body[0].expression.right.body,
+              ast.body[0].body.body[1].expression,
+              ast.body[0].body.body[1].expression.meta,
+              ast.body[0].body.body[1].expression.property,
+              ast.body[0].body.body[2].expression
             ], matches);
-            assert.isSame(6, matches.length);
+            assert.isSame(10, matches.length);
         }
 
     });

--- a/tests/queryClass.js
+++ b/tests/queryClass.js
@@ -15,9 +15,10 @@ define([
               ast.body[0].body,
               ast.body[0].body.body[0],
               ast.body[0].body.body[1],
-              ast.body[0].body.body[2]
+              ast.body[0].body.body[2],
+              ast.body[0].body.body[3]
             ], matches);
-            assert.isSame(5, matches.length);
+            assert.isSame(6, matches.length);
         },
 
         ":expression": function () {
@@ -29,9 +30,11 @@ define([
               ast.body[0].body.body[0].expression.right,
               ast.body[0].body.body[0].expression.right.body,
               ast.body[0].body.body[1].expression,
-              ast.body[0].body.body[2].expression
+              ast.body[0].body.body[2].expression,
+              ast.body[0].body.body[3].expression,
+              ast.body[0].body.body[3].expression.expressions[0]
             ], matches);
-            assert.isSame(7, matches.length);
+            assert.isSame(9, matches.length);
         },
 
         ":function": function () {
@@ -61,9 +64,11 @@ define([
               ast.body[0].body.body[0].expression.right,
               ast.body[0].body.body[0].expression.right.body,
               ast.body[0].body.body[1].expression,
-              ast.body[0].body.body[2].expression
+              ast.body[0].body.body[2].expression,
+              ast.body[0].body.body[3].expression,
+              ast.body[0].body.body[3].expression.expressions[0]
             ], matches);
-            assert.isSame(8, matches.length);
+            assert.isSame(10, matches.length);
         }
 
     });

--- a/tests/queryClass.js
+++ b/tests/queryClass.js
@@ -29,11 +29,9 @@ define([
               ast.body[0].body.body[0].expression.right,
               ast.body[0].body.body[0].expression.right.body,
               ast.body[0].body.body[1].expression,
-              ast.body[0].body.body[1].expression.meta,
-              ast.body[0].body.body[1].expression.property,
               ast.body[0].body.body[2].expression
             ], matches);
-            assert.isSame(9, matches.length);
+            assert.isSame(7, matches.length);
         },
 
         ":function": function () {
@@ -63,11 +61,9 @@ define([
               ast.body[0].body.body[0].expression.right,
               ast.body[0].body.body[0].expression.right.body,
               ast.body[0].body.body[1].expression,
-              ast.body[0].body.body[1].expression.meta,
-              ast.body[0].body.body[1].expression.property,
               ast.body[0].body.body[2].expression
             ], matches);
-            assert.isSame(10, matches.length);
+            assert.isSame(8, matches.length);
         }
 
     });


### PR DESCRIPTION
[MetaProperty] and [TemplateLiteral] are expressions, but `:expression` class does not match with those.
This PR makes the `:expression` class matching [MetaProperty] and [TemplateLiteral].

[MetaProperty]: https://github.com/estree/estree/blob/master/es2015.md#metaproperty
[TemplateLiteral]: https://github.com/estree/estree/blob/master/es2015.md#templateliteral