### PR TITLE
Fix TemplateLiterals and MetaProperties not being matched by :expression

### DIFF
--- a/esquery.js
+++ b/esquery.js
@@ -178,8 +178,9 @@
                             // fallthrough: interface Expression <: Node, Pattern { }
                         case 'expression':
                             return node.type.slice(-10) === 'Expression' ||
-                                node.type === 'Literal' ||
-                                node.type === 'Identifier';
+                                node.type.slice(-7) === 'Literal' ||
+                                node.type === 'Identifier' ||
+                                node.type === 'MetaProperty';
                         case 'function':
                             return node.type.slice(0, 8) === 'Function' ||
                                 node.type === 'ArrowFunctionExpression';

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "query"
   ],
   "devDependencies": {
-    "jstestr": ">=0.4",
-    "pegjs": "~0.7.0",
     "commonjs-everywhere": "~0.9.4",
-    "esprima": "~1.1.1"
+    "esprima": "^4.0.0",
+    "jstestr": ">=0.4",
+    "pegjs": "~0.7.0"
   },
   "license": "BSD-3-Clause",
   "engines": {

--- a/tests/fixtures/allClasses.js
+++ b/tests/fixtures/allClasses.js
@@ -1,6 +1,6 @@
 define(["esprima"], function (esprima) {
 
-    // return esprima.parse("function a(){ [a] = () => 0; }");
+    // return esprima.parse("function a(){ [a] = () => 0; `foo`; new.target; }");
 
     return {
         "type": "Program",
@@ -12,7 +12,6 @@ define(["esprima"], function (esprima) {
                     "name": "a"
                 },
                 "params": [],
-                "defaults": [],
                 "body": {
                     "type": "BlockStatement",
                     "body": [
@@ -32,26 +31,58 @@ define(["esprima"], function (esprima) {
                                 },
                                 "right": {
                                     "type": "ArrowFunctionExpression",
+                                    "id": null,
                                     "params": [],
-                                    "defaults": [],
-                                    "rest": null,
                                     "body": {
                                         "type": "Literal",
                                         "value": 0,
                                         "raw": "0"
                                     },
                                     "generator": false,
-                                    "expression": false
+                                    "expression": true,
+                                    "async": false
+                                }
+                            }
+                        },
+                        {
+                            "type": "ExpressionStatement",
+                            "expression": {
+                                "type": "TemplateLiteral",
+                                "quasis": [
+                                    {
+                                        "type": "TemplateElement",
+                                        "value": {
+                                            "raw": "foo",
+                                            "cooked": "foo"
+                                        },
+                                        "tail": true
+                                    }
+                                ],
+                                "expressions": []
+                            }
+                        },
+                        {
+                            "type": "ExpressionStatement",
+                            "expression": {
+                                "type": "MetaProperty",
+                                "meta": {
+                                    "type": "Identifier",
+                                    "name": "new"
+                                },
+                                "property": {
+                                    "type": "Identifier",
+                                    "name": "target"
                                 }
                             }
                         }
                     ]
                 },
-                "rest": null,
                 "generator": false,
-                "expression": false
+                "expression": false,
+                "async": false
             }
-        ]
+        ],
+        "sourceType": "script"
     };
 
 });

--- a/tests/queryClass.js
+++ b/tests/queryClass.js
@@ -13,9 +13,11 @@ define([
             assert.contains([
               ast.body[0],
               ast.body[0].body,
-              ast.body[0].body.body[0]
+              ast.body[0].body.body[0],
+              ast.body[0].body.body[1],
+              ast.body[0].body.body[2]
             ], matches);
-            assert.isSame(3, matches.length);
+            assert.isSame(5, matches.length);
         },
 
         ":expression": function () {
@@ -25,9 +27,13 @@ define([
               ast.body[0].body.body[0].expression,
               ast.body[0].body.body[0].expression.left.elements[0],
               ast.body[0].body.body[0].expression.right,
-              ast.body[0].body.body[0].expression.right.body
+              ast.body[0].body.body[0].expression.right.body,
+              ast.body[0].body.body[1].expression,
+              ast.body[0].body.body[2].expression,
+              ast.body[0].body.body[2].expression.meta,
+              ast.body[0].body.body[2].expression.property
             ], matches);
-            assert.isSame(5, matches.length);
+            assert.isSame(9, matches.length);
         },
 
         ":function": function () {
@@ -55,9 +61,13 @@ define([
               ast.body[0].body.body[0].expression.left,
               ast.body[0].body.body[0].expression.left.elements[0],
               ast.body[0].body.body[0].expression.right,
-              ast.body[0].body.body[0].expression.right.body
+              ast.body[0].body.body[0].expression.right.body,
+              ast.body[0].body.body[1].expression,
+              ast.body[0].body.body[2].expression,
+              ast.body[0].body.body[2].expression.meta,
+              ast.body[0].body.body[2].expression.property
             ], matches);
-            assert.isSame(6, matches.length);
+            assert.isSame(10, matches.length);
         }
 
     });


### PR DESCRIPTION
This fixes an issue where `TemplateLiteral` and `MetaProperty` nodes would not get matched by the `:expression` and `:pattern` selectors, because their node names don't end in "Expression".