### PR TITLE
Add memo cache to improve performance of repeated parse calls

### DIFF
--- a/esquery.js
+++ b/esquery.js
@@ -1,12 +1,13 @@
 /* vim: set sw=4 sts=4 : */
 (function () {
-
     var estraverse = require('estraverse');
     var parser = require('./parser');
 
     var isArray = Array.isArray || function isArray(array) {
         return {}.toString.call(array) === '[object Array]';
     };
+
+    var PARSE_CACHE = {};
 
     var LEFT_SIDE = {};
     var RIGHT_SIDE = {};
@@ -312,7 +313,12 @@
          * Parse a selector string and return its AST.
          */
         function parse(selector) {
-            return parser.parse(selector);
+            if (PARSE_CACHE[selector]) {
+                return PARSE_CACHE[selector];
+            }
+            var parsed = parser.parse(selector);
+            PARSE_CACHE[selector] = parsed;
+            return parsed;
         }
 
         /**

--- a/tests/parser.js
+++ b/tests/parser.js
@@ -2,7 +2,8 @@ define([
     "esquery",
     "jstestr/assert",
     "jstestr/test",
-], function (esquery, assert, test) {
+    "perf_hooks"
+], function (esquery, assert, test, performance) {
 
     test.defineSuite("basic query parsing", {
 
@@ -18,7 +19,11 @@ define([
             assert.isNotEqual(void 0, esquery.parse("A     "));
             assert.isNotEqual(void 0, esquery.parse(" A "));
             assert.isNotEqual(void 0, esquery.parse("     A     "));
-        }
+        },
 
+        "memoize selector parsing": function () {
+            assert.isEqual(JSON.stringify(esquery.parse("A")) === JSON.stringify(esquery.parse("A")), true);
+            assert.isEqual(esquery.parse("A") === esquery.parse("A"), true);
+        }
     });
 });

--- a/tests/parser.js
+++ b/tests/parser.js
@@ -1,9 +1,8 @@
 define([
     "esquery",
     "jstestr/assert",
-    "jstestr/test",
-    "perf_hooks"
-], function (esquery, assert, test, performance) {
+    "jstestr/test"
+], function (esquery, assert, test) {
 
     test.defineSuite("basic query parsing", {
 


### PR DESCRIPTION
I've got some code that repeatedly calls `esquery.query()` with the same selector. Obviously this can be quite slow, but instead of rewriting it all I figured it might be worth just caching internally. Keen for thoughts.