### PR TITLE
Add support for matching an attribute value against a selector

### DIFF
--- a/esquery.js
+++ b/esquery.js
@@ -137,7 +137,7 @@
                         case '<': return p < selector.value.value;
                         case '>': return p > selector.value.value;
                         case '>=': return p >= selector.value.value;
-                        case '*': return matches(p, selector.value, ancestry);
+                        case 'selector': return matches(p, selector.value, ancestry);
                     }
 
                 case 'sibling':

--- a/esquery.js
+++ b/esquery.js
@@ -137,6 +137,7 @@
                         case '<': return p < selector.value.value;
                         case '>': return p > selector.value.value;
                         case '>=': return p >= selector.value.value;
+                        case '*': return matches(p, selector.value, ancestry);
                     }
 
                 case 'sibling':

--- a/grammar.pegjs
+++ b/grammar.pegjs
@@ -22,7 +22,7 @@ start
   / _ { return void 0; }
 
 _ = " "*
-identifierName = i:[^ [\],():#!=><~+.]+ { return i.join(''); }
+identifierName = i:[^ [\],():#!=><~+.*]+ { return i.join(''); }
 binaryOp
   = _ ">" _ { return 'child'; }
   / _ "~" _ { return 'sibling'; }
@@ -64,6 +64,9 @@ attr
       return { type: 'attribute', name: name, operator: op, value: value };
     }
     / name:attrName _ op:attrOps _ value:(string / number / path) {
+      return { type: 'attribute', name: name, operator: op, value: value };
+    }
+    / name:attrName _ op:"*" _ value:selector {
       return { type: 'attribute', name: name, operator: op, value: value };
     }
     / name:attrName { return { type: 'attribute', name: name }; }

--- a/grammar.pegjs
+++ b/grammar.pegjs
@@ -22,7 +22,7 @@ start
   / _ { return void 0; }
 
 _ = " "*
-identifierName = i:[^ [\],():#!=><~+.*]+ { return i.join(''); }
+identifierName = i:[^ [\],():#!=><~+.]+ { return i.join(''); }
 binaryOp
   = _ ">" _ { return 'child'; }
   / _ "~" _ { return 'sibling'; }
@@ -66,8 +66,8 @@ attr
     / name:attrName _ op:attrOps _ value:(string / number / path) {
       return { type: 'attribute', name: name, operator: op, value: value };
     }
-    / name:attrName _ op:"*" _ value:selector {
-      return { type: 'attribute', name: name, operator: op, value: value };
+    / name:attrName _ "=(" _ value:selector ")" {
+      return { type: 'attribute', name: name, operator: 'selector', value: value };
     }
     / name:attrName { return { type: 'attribute', name: name }; }
     string

--- a/parser.js
+++ b/parser.js
@@ -230,26 +230,26 @@ var result = (function(){
         var pos0;
         
         pos0 = pos;
-        if (/^[^ [\],():#!=><~+.]/.test(input.charAt(pos))) {
+        if (/^[^ [\],():#!=><~+.*]/.test(input.charAt(pos))) {
           result1 = input.charAt(pos);
           pos++;
         } else {
           result1 = null;
           if (reportFailures === 0) {
-            matchFailed("[^ [\\],():#!=><~+.]");
+            matchFailed("[^ [\\],():#!=><~+.*]");
           }
         }
         if (result1 !== null) {
           result0 = [];
           while (result1 !== null) {
             result0.push(result1);
-            if (/^[^ [\],():#!=><~+.]/.test(input.charAt(pos))) {
+            if (/^[^ [\],():#!=><~+.*]/.test(input.charAt(pos))) {
               result1 = input.charAt(pos);
               pos++;
             } else {
               result1 = null;
               if (reportFailures === 0) {
-                matchFailed("[^ [\\],():#!=><~+.]");
+                matchFailed("[^ [\\],():#!=><~+.*]");
               }
             }
           }
@@ -1177,12 +1177,63 @@ var result = (function(){
           }
           if (result0 === null) {
             pos0 = pos;
+            pos1 = pos;
             result0 = parse_attrName();
             if (result0 !== null) {
-              result0 = (function(offset, name) { return { type: 'attribute', name: name }; })(pos0, result0);
+              result1 = parse__();
+              if (result1 !== null) {
+                if (input.charCodeAt(pos) === 42) {
+                  result2 = "*";
+                  pos++;
+                } else {
+                  result2 = null;
+                  if (reportFailures === 0) {
+                    matchFailed("\"*\"");
+                  }
+                }
+                if (result2 !== null) {
+                  result3 = parse__();
+                  if (result3 !== null) {
+                    result4 = parse_selector();
+                    if (result4 !== null) {
+                      result0 = [result0, result1, result2, result3, result4];
+                    } else {
+                      result0 = null;
+                      pos = pos1;
+                    }
+                  } else {
+                    result0 = null;
+                    pos = pos1;
+                  }
+                } else {
+                  result0 = null;
+                  pos = pos1;
+                }
+              } else {
+                result0 = null;
+                pos = pos1;
+              }
+            } else {
+              result0 = null;
+              pos = pos1;
+            }
+            if (result0 !== null) {
+              result0 = (function(offset, name, op, value) {
+                  return { type: 'attribute', name: name, operator: op, value: value };
+                })(pos0, result0[0], result0[2], result0[4]);
             }
             if (result0 === null) {
               pos = pos0;
+            }
+            if (result0 === null) {
+              pos0 = pos;
+              result0 = parse_attrName();
+              if (result0 !== null) {
+                result0 = (function(offset, name) { return { type: 'attribute', name: name }; })(pos0, result0);
+              }
+              if (result0 === null) {
+                pos = pos0;
+              }
             }
           }
         }

--- a/parser.js
+++ b/parser.js
@@ -230,26 +230,26 @@ var result = (function(){
         var pos0;
         
         pos0 = pos;
-        if (/^[^ [\],():#!=><~+.*]/.test(input.charAt(pos))) {
+        if (/^[^ [\],():#!=><~+.]/.test(input.charAt(pos))) {
           result1 = input.charAt(pos);
           pos++;
         } else {
           result1 = null;
           if (reportFailures === 0) {
-            matchFailed("[^ [\\],():#!=><~+.*]");
+            matchFailed("[^ [\\],():#!=><~+.]");
           }
         }
         if (result1 !== null) {
           result0 = [];
           while (result1 !== null) {
             result0.push(result1);
-            if (/^[^ [\],():#!=><~+.*]/.test(input.charAt(pos))) {
+            if (/^[^ [\],():#!=><~+.]/.test(input.charAt(pos))) {
               result1 = input.charAt(pos);
               pos++;
             } else {
               result1 = null;
               if (reportFailures === 0) {
-                matchFailed("[^ [\\],():#!=><~+.*]");
+                matchFailed("[^ [\\],():#!=><~+.]");
               }
             }
           }
@@ -1080,7 +1080,7 @@ var result = (function(){
           return cachedResult.result;
         }
         
-        var result0, result1, result2, result3, result4;
+        var result0, result1, result2, result3, result4, result5;
         var pos0, pos1;
         
         pos0 = pos;
@@ -1182,13 +1182,13 @@ var result = (function(){
             if (result0 !== null) {
               result1 = parse__();
               if (result1 !== null) {
-                if (input.charCodeAt(pos) === 42) {
-                  result2 = "*";
-                  pos++;
+                if (input.substr(pos, 2) === "=(") {
+                  result2 = "=(";
+                  pos += 2;
                 } else {
                   result2 = null;
                   if (reportFailures === 0) {
-                    matchFailed("\"*\"");
+                    matchFailed("\"=(\"");
                   }
                 }
                 if (result2 !== null) {
@@ -1196,7 +1196,21 @@ var result = (function(){
                   if (result3 !== null) {
                     result4 = parse_selector();
                     if (result4 !== null) {
-                      result0 = [result0, result1, result2, result3, result4];
+                      if (input.charCodeAt(pos) === 41) {
+                        result5 = ")";
+                        pos++;
+                      } else {
+                        result5 = null;
+                        if (reportFailures === 0) {
+                          matchFailed("\")\"");
+                        }
+                      }
+                      if (result5 !== null) {
+                        result0 = [result0, result1, result2, result3, result4, result5];
+                      } else {
+                        result0 = null;
+                        pos = pos1;
+                      }
                     } else {
                       result0 = null;
                       pos = pos1;
@@ -1218,9 +1232,9 @@ var result = (function(){
               pos = pos1;
             }
             if (result0 !== null) {
-              result0 = (function(offset, name, op, value) {
-                  return { type: 'attribute', name: name, operator: op, value: value };
-                })(pos0, result0[0], result0[2], result0[4]);
+              result0 = (function(offset, name, value) {
+                  return { type: 'attribute', name: name, operator: 'selector', value: value };
+                })(pos0, result0[0], result0[4]);
             }
             if (result0 === null) {
               pos = pos0;

--- a/tests/queryAttribute.js
+++ b/tests/queryAttribute.js
@@ -225,7 +225,7 @@ define([
         },
 
         "attribute with selector": function () {
-            var matches = esquery(conditional, 'IfStatement[test*LogicalExpression[operator="||"]]');
+            var matches = esquery(conditional, 'IfStatement[test=(LogicalExpression[operator="||"])]');
             assert.contains([
                 conditional.body[1]
             ], matches);

--- a/tests/queryAttribute.js
+++ b/tests/queryAttribute.js
@@ -222,6 +222,13 @@ define([
                 conditional.body[1].test.left.right,
                 conditional.body[1].alternate.test
             ], matches);
+        },
+
+        "attribute with selector": function () {
+            var matches = esquery(conditional, 'IfStatement[test*LogicalExpression[operator="||"]]');
+            assert.contains([
+                conditional.body[1]
+            ], matches);
         }
     });
 });


### PR DESCRIPTION
I tried implementing the idea described in https://github.com/estools/esquery/issues/72

Example: `IfStatement[test=(LogicalExpression[operator='||'])]`

I'm not sure if that's the best syntax, let me know what you think :)