### PR TITLE
chore: list 'has:' pseudo-class to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The following selectors are supported:
 * [following sibling](http://dev.w3.org/csswg/selectors4/#general-sibling-combinators): `node ~ sibling`
 * [adjacent sibling](http://dev.w3.org/csswg/selectors4/#adjacent-sibling-combinators): `node + adjacent`
 * [negation](http://dev.w3.org/csswg/selectors4/#negation-pseudo): `:not(ForStatement)`
+* [has](https://drafts.csswg.org/selectors-4/#has-pseudo): `:has(ForStatement)`
 * [matches-any](http://dev.w3.org/csswg/selectors4/#matches): `:matches([attr] > :first-child, :last-child)`
 * [subject indicator](http://dev.w3.org/csswg/selectors4/#subject): `!IfStatement > [name="foo"]`
 * class of AST node: `:statement`, `:expression`, `:declaration`, `:function`, or `:pattern`


### PR DESCRIPTION
I found `:has()` implementation and test code (https://github.com/estools/esquery/blob/master/tests/queryHas.js), but it isn't listed on README.