### PR TITLE
Eslint enforcement

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
         ecmaVersion: 2018
     },
     rules: {
-        semi: ["error"]
+        semi: ["error"],
+        indent: ["error", 4, {SwitchCase: 1}]
     }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,7 +33,8 @@ module.exports = {
         'prefer-destructuring': ['error'],
         'object-shorthand': ['error'],
         'object-curly-spacing': ['error', 'always'],
-        'quotes': ['error', 'single'],
+        quotes: ['error', 'single'],
+        'quote-props': ['error', 'as-needed'],
         'brace-style': ['error', '1tbs', { allowSingleLine: true }],
         'prefer-template': ['error']
     }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,9 +29,9 @@ module.exports = {
         semi: ['error'],
         indent: ['error', 4, {SwitchCase: 1}],
         'prefer-const': ['error'],
-        'no-var': [2],
-        'prefer-destructuring': [2],
-        'object-shorthand': [2],
-        'quotes': [2, 'single']
+        'no-var': ['error'],
+        'prefer-destructuring': ['error'],
+        'object-shorthand': ['error'],
+        'quotes': ['error', 'single']
     }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,12 +5,12 @@ module.exports = {
         es6: true,
         node: true
     },
-    extends: "eslint:recommended",
+    extends: 'eslint:recommended',
     globals: {
-        Atomics: "readonly",
-        SharedArrayBuffer: "readonly",
+        Atomics: 'readonly',
+        SharedArrayBuffer: 'readonly',
         // Remove after converting to ESM
-        define: "readonly"
+        define: 'readonly'
     },
     overrides: [{
         files: 'tests/**',
@@ -26,7 +26,12 @@ module.exports = {
         ecmaVersion: 2018
     },
     rules: {
-        semi: ["error"],
-        indent: ["error", 4, {SwitchCase: 1}]
+        semi: ['error'],
+        indent: ['error', 4, {SwitchCase: 1}],
+        'prefer-const': ['error'],
+        'no-var': [2],
+        'prefer-destructuring': [2],
+        'object-shorthand': [2],
+        'quotes': [2, 'single']
     }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,13 +27,14 @@ module.exports = {
     },
     rules: {
         semi: ['error'],
-        indent: ['error', 4, {SwitchCase: 1}],
+        indent: ['error', 4, { SwitchCase: 1 }],
         'prefer-const': ['error'],
         'no-var': ['error'],
         'prefer-destructuring': ['error'],
         'object-shorthand': ['error'],
+        'object-curly-spacing': ['error', 'always'],
         'quotes': ['error', 'single'],
-        'brace-style': ['error', '1tbs', {allowSingleLine: true}],
+        'brace-style': ['error', '1tbs', { allowSingleLine: true }],
         'prefer-template': ['error']
     }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
         'no-var': ['error'],
         'prefer-destructuring': ['error'],
         'object-shorthand': ['error'],
-        'quotes': ['error', 'single']
+        'quotes': ['error', 'single'],
+        'brace-style': ['error', '1tbs', {allowSingleLine: true}]
     }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,7 @@ module.exports = {
         'prefer-destructuring': ['error'],
         'object-shorthand': ['error'],
         'quotes': ['error', 'single'],
-        'brace-style': ['error', '1tbs', {allowSingleLine: true}]
+        'brace-style': ['error', '1tbs', {allowSingleLine: true}],
+        'prefer-template': ['error']
     }
 };

--- a/esquery.js
+++ b/esquery.js
@@ -118,23 +118,23 @@ function matches(node, selector, ancestry) {
                 case '=':
                     switch (selector.value.type) {
                         case 'regexp': return typeof p === 'string' && selector.value.value.test(p);
-                        case 'literal': return '' + selector.value.value === '' + p;
+                        case 'literal': return `${selector.value.value}` === `${p}`;
                         case 'type': return selector.value.value === typeof p;
                     }
-                    throw new Error('Unknown selector value type: ' + selector.value.type);
+                    throw new Error(`Unknown selector value type: ${selector.value.type}`);
                 case '!=':
                     switch (selector.value.type) {
                         case 'regexp': return !selector.value.value.test(p);
-                        case 'literal': return '' + selector.value.value !== '' + p;
+                        case 'literal': return `${selector.value.value}` !== `${p}`;
                         case 'type': return selector.value.value !== typeof p;
                     }
-                    throw new Error('Unknown selector value type: ' + selector.value.type);
+                    throw new Error(`Unknown selector value type: ${selector.value.type}`);
                 case '<=': return p <= selector.value.value;
                 case '<': return p < selector.value.value;
                 case '>': return p > selector.value.value;
                 case '>=': return p >= selector.value.value;
             }
-            throw new Error('Unknown operator: ' + selector.operator);
+            throw new Error(`Unknown operator: ${selector.operator}`);
         }
         case 'sibling':
             return matches(node, selector.right, ancestry) &&
@@ -184,10 +184,10 @@ function matches(node, selector, ancestry) {
                         node.type === 'FunctionExpression' ||
                         node.type === 'ArrowFunctionExpression';
             }
-            throw new Error('Unknown class name: ' + selector.name);
+            throw new Error(`Unknown class name: ${selector.name}`);
     }
 
-    throw new Error('Unknown selector type: ' + selector.type);
+    throw new Error(`Unknown selector type: ${selector.type}`);
 }
 
 /*

--- a/esquery.js
+++ b/esquery.js
@@ -57,7 +57,8 @@ function matches(node, selector, ancestry) {
             const ancestor = ancestry[path.length - 1];
             return inPath(node, ancestor, path);
 
-        } case 'matches':
+        }
+        case 'matches':
             for (let i = 0, l = selector.selectors.length; i < l; ++i) {
                 if (matches(node, selector.selectors[i], ancestry)) { return true; }
             }
@@ -92,7 +93,8 @@ function matches(node, selector, ancestry) {
             }
             return collector.length !== 0;
 
-        } case 'child':
+        }
+        case 'child':
             if (matches(node, selector.right, ancestry)) {
                 return matches(ancestry[0], selector.left, ancestry.slice(1));
             }
@@ -133,7 +135,8 @@ function matches(node, selector, ancestry) {
                 case '>=': return p >= selector.value.value;
             }
             throw new Error('Unknown operator: ' + selector.operator);
-        } case 'sibling':
+        }
+        case 'sibling':
             return matches(node, selector.right, ancestry) &&
                 sibling(node, selector.left, ancestry, LEFT_SIDE) ||
                 selector.left.subject &&

--- a/esquery.js
+++ b/esquery.js
@@ -2,8 +2,6 @@
 import estraverse from 'estraverse';
 import parser from './parser.js';
 
-const {isArray} = Array;
-
 const LEFT_SIDE = {};
 const RIGHT_SIDE = {};
 
@@ -27,7 +25,7 @@ function inPath(node, ancestor, path) {
     if (ancestor == null) { return false; }
     const field = ancestor[path[0]];
     const remainingPath = path.slice(1);
-    if (isArray(field)) {
+    if (Array.isArray(field)) {
         for (let i = 0, l = field.length; i < l; ++i) {
             if (inPath(node, field[i], remainingPath)) { return true; }
         }
@@ -199,7 +197,7 @@ function sibling(node, selector, ancestry, side) {
     const keys = estraverse.VisitorKeys[parent.type];
     for (let i = 0, l = keys.length; i < l; ++i) {
         const listProp = parent[keys[i]];
-        if (isArray(listProp)) {
+        if (Array.isArray(listProp)) {
             const startIndex = listProp.indexOf(node);
             if (startIndex < 0) { continue; }
             let lowerBound, upperBound;
@@ -229,7 +227,7 @@ function adjacent(node, selector, ancestry, side) {
     const keys = estraverse.VisitorKeys[parent.type];
     for (let i = 0, l = keys.length; i < l; ++i) {
         const listProp = parent[keys[i]];
-        if (isArray(listProp)) {
+        if (Array.isArray(listProp)) {
             const idx = listProp.indexOf(node);
             if (idx < 0) { continue; }
             if (side === LEFT_SIDE && idx > 0 && matches(listProp[idx - 1], selector, ancestry)) {
@@ -252,7 +250,7 @@ function nthChild(node, ancestry, idxFn) {
     const keys = estraverse.VisitorKeys[parent.type];
     for (let i = 0, l = keys.length; i < l; ++i) {
         const listProp = parent[keys[i]];
-        if (isArray(listProp)) {
+        if (Array.isArray(listProp)) {
             const idx = listProp.indexOf(node);
             if (idx >= 0 && idx === idxFn(listProp.length)) { return true; }
         }

--- a/esquery.js
+++ b/esquery.js
@@ -80,17 +80,17 @@ function matches(node, selector, ancestry) {
         case 'has':
             var a, collector = [];
             for (i = 0, l = selector.selectors.length; i < l; ++i) {
-              a = [];
-              estraverse.traverse(node, {
-                  enter: function (node, parent) {
-                      if (parent != null) { a.unshift(parent); }
-                      if (matches(node, selector.selectors[i], a)) {
-                        collector.push(node);
-                      }
-                  },
-                  leave: function () { a.shift(); },
-                  fallback: 'iteration'
-              });
+                a = [];
+                estraverse.traverse(node, {
+                    enter: function (node, parent) {
+                        if (parent != null) { a.unshift(parent); }
+                        if (matches(node, selector.selectors[i], a)) {
+                            collector.push(node);
+                        }
+                    },
+                    leave: function () { a.shift(); },
+                    fallback: 'iteration'
+                });
             }
             return collector.length !== 0;
 
@@ -202,11 +202,11 @@ function sibling(node, selector, ancestry, side) {
             startIndex = listProp.indexOf(node);
             if (startIndex < 0) { continue; }
             if (side === LEFT_SIDE) {
-              lowerBound = 0;
-              upperBound = startIndex;
+                lowerBound = 0;
+                upperBound = startIndex;
             } else {
-              lowerBound = startIndex + 1;
-              upperBound = listProp.length;
+                lowerBound = startIndex + 1;
+                upperBound = listProp.length;
             }
             for (k = lowerBound; k < upperBound; ++k) {
                 if (matches(listProp[k], selector, ancestry)) {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,4 @@
-import {terser} from 'rollup-plugin-terser';
+import { terser } from 'rollup-plugin-terser';
 
 import nodeResolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
@@ -16,7 +16,7 @@ import json from '@rollup/plugin-json';
  * @param {string} [config.format='umd']
  * @returns {external:RollupConfig}
  */
-function getRollupObject ({minifying, format = 'umd'} = {}) {
+function getRollupObject ({ minifying, format = 'umd' } = {}) {
     const nonMinified = {
         input: 'esquery.js',
         output: {
@@ -40,8 +40,8 @@ function getRollupObject ({minifying, format = 'umd'} = {}) {
 }
 
 export default [
-    getRollupObject({minifying: true, format: 'umd'}),
-    getRollupObject({minifying: false, format: 'umd'}),
-    getRollupObject({minifying: true, format: 'esm'}),
-    getRollupObject({minifying: false, format: 'esm'})
+    getRollupObject({ minifying: true, format: 'umd' }),
+    getRollupObject({ minifying: false, format: 'umd' }),
+    getRollupObject({ minifying: true, format: 'esm' }),
+    getRollupObject({ minifying: false, format: 'esm' })
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,7 +23,7 @@ function getRollupObject ({minifying, format = 'umd'} = {}) {
             format,
             sourcemap: minifying,
             file: `dist/esquery${
-                    format === 'umd' ? '' : `.${format}`
+                format === 'umd' ? '' : `.${format}`
             }${minifying ? '.min' : ''}.js`,
             name: 'esquery'
         },

--- a/tests/fixtures/allClasses.js
+++ b/tests/fixtures/allClasses.js
@@ -1,112 +1,112 @@
 export default {
-    "type": "Program",
-    "body": [
+    'type': 'Program',
+    'body': [
         {
-            "type": "FunctionDeclaration",
-            "id": {
-                "type": "Identifier",
-                "name": "a"
+            'type': 'FunctionDeclaration',
+            'id': {
+                'type': 'Identifier',
+                'name': 'a'
             },
-            "params": [],
-            "defaults": [],
-            "body": {
-                "type": "BlockStatement",
-                "body": [
+            'params': [],
+            'defaults': [],
+            'body': {
+                'type': 'BlockStatement',
+                'body': [
                     {
-                        "type": "ExpressionStatement",
-                        "expression": {
-                            "type": "AssignmentExpression",
-                            "operator": "=",
-                            "left": {
-                                "type": "ArrayPattern",
-                                "elements": [
+                        'type': 'ExpressionStatement',
+                        'expression': {
+                            'type': 'AssignmentExpression',
+                            'operator': '=',
+                            'left': {
+                                'type': 'ArrayPattern',
+                                'elements': [
                                     {
-                                        "type": "Identifier",
-                                        "name": "a"
+                                        'type': 'Identifier',
+                                        'name': 'a'
                                     }
                                 ]
                             },
-                            "right": {
-                                "type": "ArrowFunctionExpression",
-                                "params": [],
-                                "defaults": [],
-                                "rest": null,
-                                "body": {
-                                    "type": "Literal",
-                                    "value": 0,
-                                    "raw": "0"
+                            'right': {
+                                'type': 'ArrowFunctionExpression',
+                                'params': [],
+                                'defaults': [],
+                                'rest': null,
+                                'body': {
+                                    'type': 'Literal',
+                                    'value': 0,
+                                    'raw': '0'
                                 },
-                                "generator": false,
-                                "expression": false
+                                'generator': false,
+                                'expression': false
                             }
                         }
                     },
                     {
-                        "type": "ExpressionStatement",
-                        "expression": {
-                            "type": "MetaProperty",
-                            "meta": {
-                                "type": "Identifier",
-                                "name": "new",
+                        'type': 'ExpressionStatement',
+                        'expression': {
+                            'type': 'MetaProperty',
+                            'meta': {
+                                'type': 'Identifier',
+                                'name': 'new',
                             },
-                            "property": {
-                                "type": "Identifier",
-                                "name": "target",
+                            'property': {
+                                'type': 'Identifier',
+                                'name': 'target',
                             },
                         },
                     },
                     {
-                        "type": "ExpressionStatement",
-                        "expression": {
-                            "type": "TemplateLiteral",
-                            "quasis": [
+                        'type': 'ExpressionStatement',
+                        'expression': {
+                            'type': 'TemplateLiteral',
+                            'quasis': [
                                 {
-                                    "type": "TemplateElement",
-                                    "value": {
-                                        "raw": "test",
-                                        "cooked": "test"
+                                    'type': 'TemplateElement',
+                                    'value': {
+                                        'raw': 'test',
+                                        'cooked': 'test'
                                     },
-                                    "tail": true,
+                                    'tail': true,
                                 }
                             ],
-                            "expressions": [],
+                            'expressions': [],
                         },
                     },
                     {
-                        "type": "ExpressionStatement",
-                        "expression": {
-                            "type": "TemplateLiteral",
-                            "quasis": [
+                        'type': 'ExpressionStatement',
+                        'expression': {
+                            'type': 'TemplateLiteral',
+                            'quasis': [
                                 {
-                                    "type": "TemplateElement",
-                                    "value": {
-                                        "raw": "hello,",
-                                        "cooked": "hello,"
+                                    'type': 'TemplateElement',
+                                    'value': {
+                                        'raw': 'hello,',
+                                        'cooked': 'hello,'
                                     },
-                                    "tail": false,
+                                    'tail': false,
                                 },
                                 {
-                                    "type": "TemplateElement",
-                                    "value": {
-                                        "raw": "",
-                                        "cooked": ""
+                                    'type': 'TemplateElement',
+                                    'value': {
+                                        'raw': '',
+                                        'cooked': ''
                                     },
-                                    "tail": true,
+                                    'tail': true,
                                 }
                             ],
-                            "expressions": [
+                            'expressions': [
                                 {
-                                    "type": "Identifier",
-                                    "name": "name",
+                                    'type': 'Identifier',
+                                    'name': 'name',
                                 }
                             ],
                         },
                     }
                 ]
             },
-            "rest": null,
-            "generator": false,
-            "expression": false
+            'rest': null,
+            'generator': false,
+            'expression': false
         }
     ]
 };

--- a/tests/fixtures/allClasses.js
+++ b/tests/fixtures/allClasses.js
@@ -1,112 +1,112 @@
 export default {
-    'type': 'Program',
-    'body': [
+    type: 'Program',
+    body: [
         {
-            'type': 'FunctionDeclaration',
-            'id': {
-                'type': 'Identifier',
-                'name': 'a'
+            type: 'FunctionDeclaration',
+            id: {
+                type: 'Identifier',
+                name: 'a'
             },
-            'params': [],
-            'defaults': [],
-            'body': {
-                'type': 'BlockStatement',
-                'body': [
+            params: [],
+            defaults: [],
+            body: {
+                type: 'BlockStatement',
+                body: [
                     {
-                        'type': 'ExpressionStatement',
-                        'expression': {
-                            'type': 'AssignmentExpression',
-                            'operator': '=',
-                            'left': {
-                                'type': 'ArrayPattern',
-                                'elements': [
+                        type: 'ExpressionStatement',
+                        expression: {
+                            type: 'AssignmentExpression',
+                            operator: '=',
+                            left: {
+                                type: 'ArrayPattern',
+                                elements: [
                                     {
-                                        'type': 'Identifier',
-                                        'name': 'a'
+                                        type: 'Identifier',
+                                        name: 'a'
                                     }
                                 ]
                             },
-                            'right': {
-                                'type': 'ArrowFunctionExpression',
-                                'params': [],
-                                'defaults': [],
-                                'rest': null,
-                                'body': {
-                                    'type': 'Literal',
-                                    'value': 0,
-                                    'raw': '0'
+                            right: {
+                                type: 'ArrowFunctionExpression',
+                                params: [],
+                                defaults: [],
+                                rest: null,
+                                body: {
+                                    type: 'Literal',
+                                    value: 0,
+                                    raw: '0'
                                 },
-                                'generator': false,
-                                'expression': false
+                                generator: false,
+                                expression: false
                             }
                         }
                     },
                     {
-                        'type': 'ExpressionStatement',
-                        'expression': {
-                            'type': 'MetaProperty',
-                            'meta': {
-                                'type': 'Identifier',
-                                'name': 'new',
+                        type: 'ExpressionStatement',
+                        expression: {
+                            type: 'MetaProperty',
+                            meta: {
+                                type: 'Identifier',
+                                name: 'new',
                             },
-                            'property': {
-                                'type': 'Identifier',
-                                'name': 'target',
+                            property: {
+                                type: 'Identifier',
+                                name: 'target',
                             },
                         },
                     },
                     {
-                        'type': 'ExpressionStatement',
-                        'expression': {
-                            'type': 'TemplateLiteral',
-                            'quasis': [
+                        type: 'ExpressionStatement',
+                        expression: {
+                            type: 'TemplateLiteral',
+                            quasis: [
                                 {
-                                    'type': 'TemplateElement',
-                                    'value': {
-                                        'raw': 'test',
-                                        'cooked': 'test'
+                                    type: 'TemplateElement',
+                                    value: {
+                                        raw: 'test',
+                                        cooked: 'test'
                                     },
-                                    'tail': true,
+                                    tail: true,
                                 }
                             ],
-                            'expressions': [],
+                            expressions: [],
                         },
                     },
                     {
-                        'type': 'ExpressionStatement',
-                        'expression': {
-                            'type': 'TemplateLiteral',
-                            'quasis': [
+                        type: 'ExpressionStatement',
+                        expression: {
+                            type: 'TemplateLiteral',
+                            quasis: [
                                 {
-                                    'type': 'TemplateElement',
-                                    'value': {
-                                        'raw': 'hello,',
-                                        'cooked': 'hello,'
+                                    type: 'TemplateElement',
+                                    value: {
+                                        raw: 'hello,',
+                                        cooked: 'hello,'
                                     },
-                                    'tail': false,
+                                    tail: false,
                                 },
                                 {
-                                    'type': 'TemplateElement',
-                                    'value': {
-                                        'raw': '',
-                                        'cooked': ''
+                                    type: 'TemplateElement',
+                                    value: {
+                                        raw: '',
+                                        cooked: ''
                                     },
-                                    'tail': true,
+                                    tail: true,
                                 }
                             ],
-                            'expressions': [
+                            expressions: [
                                 {
-                                    'type': 'Identifier',
-                                    'name': 'name',
+                                    type: 'Identifier',
+                                    name: 'name',
                                 }
                             ],
                         },
                     }
                 ]
             },
-            'rest': null,
-            'generator': false,
-            'expression': false
+            rest: null,
+            generator: false,
+            expression: false
         }
     ]
 };

--- a/tests/fixtures/allClasses.js
+++ b/tests/fixtures/allClasses.js
@@ -42,35 +42,35 @@ export default {
                         }
                     },
                     {
-                      "type": "ExpressionStatement",
-                      "expression": {
-                        "type": "MetaProperty",
-                        "meta": {
-                          "type": "Identifier",
-                          "name": "new",
+                        "type": "ExpressionStatement",
+                        "expression": {
+                            "type": "MetaProperty",
+                            "meta": {
+                                "type": "Identifier",
+                                "name": "new",
+                            },
+                            "property": {
+                                "type": "Identifier",
+                                "name": "target",
+                            },
                         },
-                        "property": {
-                          "type": "Identifier",
-                          "name": "target",
-                        },
-                      },
                     },
                     {
-                      "type": "ExpressionStatement",
-                      "expression": {
-                        "type": "TemplateLiteral",
-                        "quasis": [
-                          {
-                            "type": "TemplateElement",
-                            "value": {
-                              "raw": "test",
-                              "cooked": "test"
-                            },
-                            "tail": true,
-                          }
-                        ],
-                        "expressions": [],
-                      },
+                        "type": "ExpressionStatement",
+                        "expression": {
+                            "type": "TemplateLiteral",
+                            "quasis": [
+                                {
+                                    "type": "TemplateElement",
+                                    "value": {
+                                        "raw": "test",
+                                        "cooked": "test"
+                                    },
+                                    "tail": true,
+                                }
+                            ],
+                            "expressions": [],
+                        },
                     },
                     {
                         "type": "ExpressionStatement",

--- a/tests/fixtures/bigArray.js
+++ b/tests/fixtures/bigArray.js
@@ -1,6 +1,6 @@
-import * as esprima from "esprima";
+import * as esprima from 'esprima';
 
-var parsed = esprima.parse(
+const parsed = esprima.parse(
     '[1, 2, 3, foo, bar, 4, 5, baz, qux, 6]'
 );
 

--- a/tests/fixtures/conditional.js
+++ b/tests/fixtures/conditional.js
@@ -1,8 +1,8 @@
-import * as esprima from "esprima";
+import * as esprima from 'esprima';
 
-var parsed = esprima.parse(
-    "if (x === 1) { foo(); } else { x = 2; }\n" +
-    "if (x == 'test' && true || x) { y = -1; } else if (false) { y = 1; }"
+const parsed = esprima.parse(
+    'if (x === 1) { foo(); } else { x = 2; }\n' +
+    'if (x == \'test\' && true || x) { y = -1; } else if (false) { y = 1; }'
 );
 
 export default parsed;

--- a/tests/fixtures/conditionalLong.js
+++ b/tests/fixtures/conditionalLong.js
@@ -1,17 +1,17 @@
-import * as esprima from "esprima";
+import * as esprima from 'esprima';
 
-var parsed = esprima.parse(
-    "if (x === 1) { foo(1); }" +
-    "if (x === 2) { foo(2); }" +
-    "if (x === 3) { foo(3); }" +
-    "if (x === 4) { foo(4); }" +
-    "if (x === 5) { foo(5); }" +
-    "if (x === 6) { foo(6); }" +
-    "if (x === 7) { foo(7); }" +
-    "if (x === 8) { foo(8); }" +
-    "if (x === 9) { foo(9); }" +
-    "if (x === 10) { foo(10); }" +
-    "if (x === 11) { foo(11); }"
+const parsed = esprima.parse(
+    'if (x === 1) { foo(1); }' +
+    'if (x === 2) { foo(2); }' +
+    'if (x === 3) { foo(3); }' +
+    'if (x === 4) { foo(4); }' +
+    'if (x === 5) { foo(5); }' +
+    'if (x === 6) { foo(6); }' +
+    'if (x === 7) { foo(7); }' +
+    'if (x === 8) { foo(8); }' +
+    'if (x === 9) { foo(9); }' +
+    'if (x === 10) { foo(10); }' +
+    'if (x === 11) { foo(11); }'
 );
 
 export default parsed;

--- a/tests/fixtures/forLoop.js
+++ b/tests/fixtures/forLoop.js
@@ -1,5 +1,5 @@
-import * as esprima from "esprima";
+import * as esprima from 'esprima';
 
-var parsed = esprima.parse("for (i = 0; i < foo.length; i++) { foo[i](); }");
+const parsed = esprima.parse('for (i = 0; i < foo.length; i++) { foo[i](); }');
 
 export default parsed;

--- a/tests/fixtures/literal.js
+++ b/tests/fixtures/literal.js
@@ -1,10 +1,10 @@
-import * as esprima from "esprima";
+import * as esprima from 'esprima';
 
-var parsed = esprima.parse(
-    "var y = '\b\f\\n\\r\t\v and just a  back\\slash';\n" +
-    "var x = 21.35;" +
-    "var z = '\\z';" +
-    "var a = 'abc\\z';"
+const parsed = esprima.parse(
+    'var y = \'\b\f\\n\\r\t\v and just a  back\\slash\';\n' +
+    'var x = 21.35;' +
+    'var z = \'\\z\';' +
+    'var a = \'abc\\z\';'
 );
 
 export default parsed;

--- a/tests/fixtures/nestedFunctions.js
+++ b/tests/fixtures/nestedFunctions.js
@@ -1,12 +1,12 @@
-import * as esprima from "esprima";
+import * as esprima from 'esprima';
 
-var parsed = esprima.parse(
-    "function foo() {\n" +
-    "  var x = 1;\n" +
-    "  function bar() {\n" +
-    "    x = 2;\n" +
-    "  }\n" +
-    "}\n"
+const parsed = esprima.parse(
+    'function foo() {\n' +
+    '  var x = 1;\n' +
+    '  function bar() {\n' +
+    '    x = 2;\n' +
+    '  }\n' +
+    '}\n'
 );
 
 export default parsed;

--- a/tests/fixtures/simpleFunction.js
+++ b/tests/fixtures/simpleFunction.js
@@ -1,11 +1,11 @@
-import * as esprima from "esprima";
+import * as esprima from 'esprima';
 
-var parsed = esprima.parse(
-    "function foo(x, y) {\n" +
-    "  var z = x + y;\n" +
-    "  z++;\n" +
-    "  return z;\n" +
-    "}\n"
+const parsed = esprima.parse(
+    'function foo(x, y) {\n' +
+    '  var z = x + y;\n' +
+    '  z++;\n' +
+    '  return z;\n' +
+    '}\n'
 );
 
 export default parsed;

--- a/tests/fixtures/simpleProgram.js
+++ b/tests/fixtures/simpleProgram.js
@@ -1,10 +1,10 @@
-import * as esprima from "esprima";
+import * as esprima from 'esprima';
 
-var parsed = esprima.parse(
-    "var x = 1;\n" +
-    "var y = 'y';\n" +
-    "x = x * 2;\n" +
-    "if (y) { y += 'z'; }\n"
+const parsed = esprima.parse(
+    'var x = 1;\n' +
+    'var y = \'y\';\n' +
+    'x = x * 2;\n' +
+    'if (y) { y += \'z\'; }\n'
 );
 
 export default parsed;

--- a/tests/fixtures/switchStatement.js
+++ b/tests/fixtures/switchStatement.js
@@ -1,12 +1,12 @@
-import * as esprima from "esprima";
+import * as esprima from 'esprima';
 
-var parsed = esprima.parse(
-    "var x = 1;\n" +
-    "switch (x) {\n" +
-    "  case 0: foo1(); break;\n" +
-    "  case 1: foo2(); break;\n" +
-    "  default: x = 1; break;\n" +
-    "}\n"
+const parsed = esprima.parse(
+    'var x = 1;\n' +
+    'switch (x) {\n' +
+    '  case 0: foo1(); break;\n' +
+    '  case 1: foo2(); break;\n' +
+    '  default: x = 1; break;\n' +
+    '}\n'
 );
 
 export default parsed;

--- a/tests/fixtures/unknownNodeTypeAST.js
+++ b/tests/fixtures/unknownNodeTypeAST.js
@@ -5,9 +5,9 @@
  * type aType = {};
  *
  */
-import * as esprima from "esprima";
+import * as esprima from 'esprima';
 
-var program = esprima.parse("var x = 's'");
+const program = esprima.parse('var x = \'s\'');
 program.body[0].type = 'TypeAlias';
 
 export default program;

--- a/tests/fixtures/whileLoop.js
+++ b/tests/fixtures/whileLoop.js
@@ -1,8 +1,8 @@
-import * as esprima from "esprima";
+import * as esprima from 'esprima';
 
-var parsed = esprima.parse(
-    "x = 10;\n" +
-    "while (x > 0) { x--; }"
+const parsed = esprima.parse(
+    'x = 10;\n' +
+    'while (x > 0) { x--; }'
 );
 
 export default parsed;

--- a/tests/match.js
+++ b/tests/match.js
@@ -1,10 +1,10 @@
-import esquery from "../esquery.js";
-import forLoop from "./fixtures/forLoop.js";
-import ast from "./fixtures/allClasses.js";
+import esquery from '../esquery.js';
+import forLoop from './fixtures/forLoop.js';
+import ast from './fixtures/allClasses.js';
 
 describe('match', function () {
 
-    it("unknown selector type", function () {
+    it('unknown selector type', function () {
         assert.throws(function () {
             esquery.match(forLoop, {
                 type: 'badType'
@@ -12,7 +12,7 @@ describe('match', function () {
         }, Error);
     });
 
-    it("unknown selector type", function () {
+    it('unknown selector type', function () {
         assert.throws(function () {
             esquery.match(forLoop, {
                 type: 'class',
@@ -21,7 +21,7 @@ describe('match', function () {
         }, Error);
     });
 
-    it("unknown class name", function () {
+    it('unknown class name', function () {
         assert.throws(function () {
             esquery.match(ast, {
                 type: 'class',
@@ -30,7 +30,7 @@ describe('match', function () {
         }, Error);
     });
 
-    it("unknown type", function () {
+    it('unknown type', function () {
         assert.throws(function () {
             esquery.match(forLoop, {
                 type: 'attribute',
@@ -48,7 +48,7 @@ describe('match', function () {
         }, Error);
     });
 
-    it("unknown operator", function () {
+    it('unknown operator', function () {
         assert.throws(function () {
             esquery.match(forLoop, {
                 type: 'attribute',
@@ -60,11 +60,11 @@ describe('match', function () {
 
     // Can remove need for this if remove `subjects`' `hasOwnProperty`
     //  check in favor of for-of (Node >=6.9.2) or use `Object.keys`
-    it("selector with non-own properties", function () {
+    it('selector with non-own properties', function () {
         assert.throws(function () {
             function Selector () {}
             Selector.prototype.inheritedMethod = function () {};
-            var sel = new Selector();
+            const sel = new Selector();
             sel.type = 'class';
             sel.name = 'badName';
             sel.value = { type: 'foobar' };

--- a/tests/matches.js
+++ b/tests/matches.js
@@ -1,11 +1,11 @@
-import esquery from "../esquery.js";
-import forLoop from "./fixtures/forLoop.js";
-import simpleProgram from "./fixtures/simpleProgram.js";
-import conditional from "./fixtures/conditional.js";
+import esquery from '../esquery.js';
+import forLoop from './fixtures/forLoop.js';
+import simpleProgram from './fixtures/simpleProgram.js';
+import conditional from './fixtures/conditional.js';
 
 describe('matches', function () {
-    it("falsey node", function () {
-        let selector = esquery.parse('*');
+    it('falsey node', function () {
+        const selector = esquery.parse('*');
 
         assert.equal(false, esquery.matches(
             null,
@@ -26,7 +26,7 @@ describe('matches', function () {
         ));
     });
 
-    it("falsey selector", function () {
+    it('falsey selector', function () {
         assert.equal(true, esquery.matches(
             forLoop,
             null,
@@ -46,8 +46,8 @@ describe('matches', function () {
         ));
     });
 
-    it("falsey ancestry", function () {
-        let selector = esquery.parse('*');
+    it('falsey ancestry', function () {
+        const selector = esquery.parse('*');
 
         assert.doesNotThrow(() => {
             esquery.matches(

--- a/tests/queryAttribute.js
+++ b/tests/queryAttribute.js
@@ -1,14 +1,14 @@
-import esquery from "../esquery.js";
-import literal from "./fixtures/literal.js";
-import conditional from "./fixtures/conditional.js";
-import forLoop from "./fixtures/forLoop.js";
-import simpleFunction from "./fixtures/simpleFunction.js";
-import simpleProgram from "./fixtures/simpleProgram.js";
+import esquery from '../esquery.js';
+import literal from './fixtures/literal.js';
+import conditional from './fixtures/conditional.js';
+import forLoop from './fixtures/forLoop.js';
+import simpleFunction from './fixtures/simpleFunction.js';
+import simpleProgram from './fixtures/simpleProgram.js';
 
-describe("Attribute query", function () {
+describe('Attribute query', function () {
 
-    it("conditional", function () {
-        var matches = esquery(conditional, "[name=\"x\"]");
+    it('conditional', function () {
+        let matches = esquery(conditional, '[name="x"]');
         assert.includeMembers(matches, [
             conditional.body[0].test.left,
             conditional.body[0].alternate.body[0].expression.left,
@@ -16,12 +16,12 @@ describe("Attribute query", function () {
             conditional.body[1].test.right
         ]);
 
-        matches = esquery(conditional, "[callee.name=\"foo\"]");
+        matches = esquery(conditional, '[callee.name="foo"]');
         assert.includeMembers(matches, [
             conditional.body[0].consequent.body[0].expression
         ]);
 
-        matches = esquery(conditional, "[operator]");
+        matches = esquery(conditional, '[operator]');
         assert.includeMembers(matches, [
             conditional.body[0].test,
             conditional.body[0].alternate.body[0].expression,
@@ -30,28 +30,28 @@ describe("Attribute query", function () {
             conditional.body[1].test.left.left
         ]);
 
-        matches = esquery(conditional, "[prefix=true]");
+        matches = esquery(conditional, '[prefix=true]');
         assert.includeMembers(matches, [
             conditional.body[1].consequent.body[0].expression.right
         ]);
     });
 
-    it("literal with special escapes", function () {
-        var matches = esquery(literal, "Literal[value='\\b\\f\\n\\r\\t\\v and just a \\ back\\slash']");
+    it('literal with special escapes', function () {
+        const matches = esquery(literal, 'Literal[value=\'\\b\\f\\n\\r\\t\\v and just a \\ back\\slash\']');
         assert.includeMembers(matches, [
             literal.body[0].declarations[0].init
         ]);
     });
 
-    it("literal with decimal", function () {
-        var matches = esquery(literal, "Literal[value=21.35]");
+    it('literal with decimal', function () {
+        const matches = esquery(literal, 'Literal[value=21.35]');
         assert.includeMembers(matches, [
             literal.body[1].declarations[0].init
         ]);
     });
 
-    it("literal with extra whitespace", function () {
-        var matches = esquery(literal, "Literal[value  =  21.35]");
+    it('literal with extra whitespace', function () {
+        const matches = esquery(literal, 'Literal[value  =  21.35]');
         assert.includeMembers(matches, [
             literal.body[1].declarations[0].init
         ]);
@@ -60,37 +60,37 @@ describe("Attribute query", function () {
     // Not sure what AST would be producing an empty string, so
     //  just checking this acceptable grammar doesn't fail and is
     //  covered.
-    it("literal with empty string and dot", function () {
-        var matches = esquery(literal, "Literal[.value='abc']");
+    it('literal with empty string and dot', function () {
+        const matches = esquery(literal, 'Literal[.value=\'abc\']');
         assert.lengthOf(matches, 0);
     });
 
-    it("literal with backslashes", function () {
-        var matches = esquery(literal, "Literal[value=\"\\z\"]");
+    it('literal with backslashes', function () {
+        const matches = esquery(literal, 'Literal[value="\\z"]');
         assert.includeMembers(matches, [
             literal.body[2].declarations[0].init
         ]);
     });
 
-    it("literal with backslash after beginning", function () {
-        var matches = esquery(literal, "Literal[value=\"abc\\z\"]");
+    it('literal with backslash after beginning', function () {
+        const matches = esquery(literal, 'Literal[value="abc\\z"]');
         assert.includeMembers(matches, [
             literal.body[3].declarations[0].init
         ]);
     });
 
-    it("for loop", function () {
-        var matches = esquery(forLoop, "[operator=\"=\"]");
+    it('for loop', function () {
+        let matches = esquery(forLoop, '[operator="="]');
         assert.includeMembers(matches, [
             forLoop.body[0].init
         ]);
 
-        matches = esquery(forLoop, "[object.name=\"foo\"]");
+        matches = esquery(forLoop, '[object.name="foo"]');
         assert.includeMembers(matches, [
             forLoop.body[0].test.right
         ]);
 
-        matches = esquery(forLoop, "[operator]");
+        matches = esquery(forLoop, '[operator]');
         assert.includeMembers(matches, [
             forLoop.body[0].init,
             forLoop.body[0].test,
@@ -98,44 +98,44 @@ describe("Attribute query", function () {
         ]);
     });
 
-    it("simple function", function () {
-        var matches = esquery(simpleFunction, "[kind=\"var\"]");
+    it('simple function', function () {
+        let matches = esquery(simpleFunction, '[kind="var"]');
         assert.includeMembers(matches, [
             simpleFunction.body[0].body.body[0]
         ]);
 
-        matches = esquery(simpleFunction, "[id.name=\"foo\"]");
+        matches = esquery(simpleFunction, '[id.name="foo"]');
         assert.includeMembers(matches, [
             simpleFunction.body[0]
         ]);
 
-        matches = esquery(simpleFunction, "[left]");
+        matches = esquery(simpleFunction, '[left]');
         assert.includeMembers(matches, [
             simpleFunction.body[0].body.body[0].declarations[0].init
         ]);
     });
 
-    it("simple program", function () {
-        var matches = esquery(simpleProgram, "[kind=\"var\"]");
+    it('simple program', function () {
+        let matches = esquery(simpleProgram, '[kind="var"]');
         assert.includeMembers(matches, [
             simpleProgram.body[0],
             simpleProgram.body[1]
         ]);
 
-        matches = esquery(simpleProgram, "[id.name=\"y\"]");
+        matches = esquery(simpleProgram, '[id.name="y"]');
         assert.includeMembers(matches, [
             simpleProgram.body[1].declarations[0]
         ]);
 
-        matches = esquery(simpleProgram, "[body]");
+        matches = esquery(simpleProgram, '[body]');
         assert.includeMembers(matches, [
             simpleProgram,
             simpleProgram.body[3].consequent
         ]);
     });
 
-    it("conditional regexp", function () {
-        var matches = esquery(conditional, "[name=/x|foo/]");
+    it('conditional regexp', function () {
+        const matches = esquery(conditional, '[name=/x|foo/]');
         assert.includeMembers(matches, [
             conditional.body[0].test.left,
             conditional.body[0].consequent.body[0].expression.callee,
@@ -143,8 +143,8 @@ describe("Attribute query", function () {
         ]);
     });
 
-    it("simple function regexp", function () {
-        var matches = esquery(simpleFunction, "[name=/x|foo/]");
+    it('simple function regexp', function () {
+        const matches = esquery(simpleFunction, '[name=/x|foo/]');
         assert.includeMembers(matches, [
             simpleFunction.body[0].id,
             simpleFunction.body[0].params[0],
@@ -152,15 +152,15 @@ describe("Attribute query", function () {
         ]);
     });
 
-    it("simple function numeric", function () {
-        var matches = esquery(simpleFunction, "FunctionDeclaration[params.0.name=x]");
+    it('simple function numeric', function () {
+        const matches = esquery(simpleFunction, 'FunctionDeclaration[params.0.name=x]');
         assert.includeMembers(matches, [
             simpleFunction.body[0]
         ]);
     });
 
-    it("simple program regexp", function () {
-        var matches = esquery(simpleProgram, "[name=/[asdfy]/]");
+    it('simple program regexp', function () {
+        const matches = esquery(simpleProgram, '[name=/[asdfy]/]');
         assert.includeMembers(matches, [
             simpleProgram.body[1].declarations[0].id,
             simpleProgram.body[3].test,
@@ -168,8 +168,8 @@ describe("Attribute query", function () {
         ]);
     });
 
-    it("for loop regexp", function () {
-        var matches = esquery(forLoop, "[name=/i|foo/]");
+    it('for loop regexp', function () {
+        const matches = esquery(forLoop, '[name=/i|foo/]');
         assert.includeMembers(matches, [
             forLoop.body[0].init.left,
             forLoop.body[0].test.left,
@@ -180,21 +180,21 @@ describe("Attribute query", function () {
         ]);
     });
 
-    it("nonexistent attribute regexp", function () {
-        var matches = esquery(conditional, '[foobar=/./]');
+    it('nonexistent attribute regexp', function () {
+        const matches = esquery(conditional, '[foobar=/./]');
         assert.lengthOf(matches, 0);
     });
 
-    it("not string", function () {
-        var matches = esquery(conditional, '[name!="x"]');
+    it('not string', function () {
+        const matches = esquery(conditional, '[name!="x"]');
         assert.includeMembers(matches, [
             conditional.body[0].consequent.body[0].expression.callee,
             conditional.body[1].consequent.body[0].expression.left
         ]);
     });
 
-    it("not type", function () {
-        var matches = esquery(conditional, '[value!=type(number)]');
+    it('not type', function () {
+        const matches = esquery(conditional, '[value!=type(number)]');
         assert.includeMembers(matches, [
             conditional.body[1].test.left.left.right,
             conditional.body[1].test.left.right,
@@ -202,15 +202,15 @@ describe("Attribute query", function () {
         ]);
     });
 
-    it("not regexp", function () {
-        var matches = esquery(conditional, '[name!=/x|y/]');
+    it('not regexp', function () {
+        const matches = esquery(conditional, '[name!=/x|y/]');
         assert.includeMembers(matches, [
             conditional.body[0].consequent.body[0].expression.callee
         ]);
     });
 
-    it("less than", function () {
-        var matches = esquery(conditional, "[body.length<2]");
+    it('less than', function () {
+        const matches = esquery(conditional, '[body.length<2]');
         assert.includeMembers(matches, [
             conditional.body[0].consequent,
             conditional.body[0].alternate,
@@ -219,15 +219,15 @@ describe("Attribute query", function () {
         ]);
     });
 
-    it("greater than", function () {
-        var matches = esquery(conditional, "[body.length>1]");
+    it('greater than', function () {
+        const matches = esquery(conditional, '[body.length>1]');
         assert.includeMembers(matches, [
             conditional
         ]);
     });
 
-    it("less than or equal", function () {
-        var matches = esquery(conditional, "[body.length<=2]");
+    it('less than or equal', function () {
+        const matches = esquery(conditional, '[body.length<=2]');
         assert.includeMembers(matches, [
             conditional,
             conditional.body[0].consequent,
@@ -237,8 +237,8 @@ describe("Attribute query", function () {
         ]);
     });
 
-    it("greater than or equal", function () {
-        var matches = esquery(conditional, "[body.length>=1]");
+    it('greater than or equal', function () {
+        const matches = esquery(conditional, '[body.length>=1]');
         assert.includeMembers(matches, [
             conditional,
             conditional.body[0].consequent,
@@ -248,15 +248,15 @@ describe("Attribute query", function () {
         ]);
     });
 
-    it("attribute type", function () {
-        var matches = esquery(conditional, "[test=type(object)]");
+    it('attribute type', function () {
+        let matches = esquery(conditional, '[test=type(object)]');
         assert.includeMembers(matches, [
             conditional.body[0],
             conditional.body[1],
             conditional.body[1].alternate
         ]);
 
-        matches = esquery(conditional, "[value=type(boolean)]");
+        matches = esquery(conditional, '[value=type(boolean)]');
         assert.includeMembers(matches, [
             conditional.body[1].test.left.right,
             conditional.body[1].alternate.test

--- a/tests/queryClass.js
+++ b/tests/queryClass.js
@@ -1,10 +1,10 @@
-import esquery from "../esquery.js";
-import ast from "./fixtures/allClasses.js";
+import esquery from '../esquery.js';
+import ast from './fixtures/allClasses.js';
 
-describe("Class query", function () {
+describe('Class query', function () {
 
-    it(":statement", function () {
-        var matches = esquery(ast, ":statement");
+    it(':statement', function () {
+        const matches = esquery(ast, ':statement');
         assert.includeMembers(matches, [
             ast.body[0],
             ast.body[0].body,
@@ -16,8 +16,8 @@ describe("Class query", function () {
         assert.equal(6, matches.length);
     });
 
-    it(":expression", function () {
-        var matches = esquery(ast, ":Expression");
+    it(':expression', function () {
+        const matches = esquery(ast, ':Expression');
         assert.includeMembers(matches, [
             ast.body[0].id,
             ast.body[0].body.body[0].expression,
@@ -32,8 +32,8 @@ describe("Class query", function () {
         assert.equal(9, matches.length);
     });
 
-    it(":function", function () {
-        var matches = esquery(ast, ":FUNCTION");
+    it(':function', function () {
+        const matches = esquery(ast, ':FUNCTION');
         assert.includeMembers(matches, [
             ast.body[0],
             ast.body[0].body.body[0].expression.right
@@ -41,16 +41,16 @@ describe("Class query", function () {
         assert.equal(2, matches.length);
     });
 
-    it(":declaration", function () {
-        var matches = esquery(ast, ":declaratioN");
+    it(':declaration', function () {
+        const matches = esquery(ast, ':declaratioN');
         assert.includeMembers(matches, [
             ast.body[0]
         ]);
         assert.equal(1, matches.length);
     });
 
-    it(":pattern", function () {
-        var matches = esquery(ast, ":paTTern");
+    it(':pattern', function () {
+        const matches = esquery(ast, ':paTTern');
         assert.includeMembers(matches, [
             ast.body[0].id,
             ast.body[0].body.body[0].expression,

--- a/tests/queryClass.js
+++ b/tests/queryClass.js
@@ -6,12 +6,12 @@ describe("Class query", function () {
     it(":statement", function () {
         var matches = esquery(ast, ":statement");
         assert.includeMembers(matches, [
-          ast.body[0],
-          ast.body[0].body,
-          ast.body[0].body.body[0],
-          ast.body[0].body.body[1],
-          ast.body[0].body.body[2],
-          ast.body[0].body.body[3]
+            ast.body[0],
+            ast.body[0].body,
+            ast.body[0].body.body[0],
+            ast.body[0].body.body[1],
+            ast.body[0].body.body[2],
+            ast.body[0].body.body[3]
         ]);
         assert.equal(6, matches.length);
     });
@@ -19,15 +19,15 @@ describe("Class query", function () {
     it(":expression", function () {
         var matches = esquery(ast, ":Expression");
         assert.includeMembers(matches, [
-          ast.body[0].id,
-          ast.body[0].body.body[0].expression,
-          ast.body[0].body.body[0].expression.left.elements[0],
-          ast.body[0].body.body[0].expression.right,
-          ast.body[0].body.body[0].expression.right.body,
-          ast.body[0].body.body[1].expression,
-          ast.body[0].body.body[2].expression,
-          ast.body[0].body.body[3].expression,
-          ast.body[0].body.body[3].expression.expressions[0]
+            ast.body[0].id,
+            ast.body[0].body.body[0].expression,
+            ast.body[0].body.body[0].expression.left.elements[0],
+            ast.body[0].body.body[0].expression.right,
+            ast.body[0].body.body[0].expression.right.body,
+            ast.body[0].body.body[1].expression,
+            ast.body[0].body.body[2].expression,
+            ast.body[0].body.body[3].expression,
+            ast.body[0].body.body[3].expression.expressions[0]
         ]);
         assert.equal(9, matches.length);
     });
@@ -35,8 +35,8 @@ describe("Class query", function () {
     it(":function", function () {
         var matches = esquery(ast, ":FUNCTION");
         assert.includeMembers(matches, [
-          ast.body[0],
-          ast.body[0].body.body[0].expression.right
+            ast.body[0],
+            ast.body[0].body.body[0].expression.right
         ]);
         assert.equal(2, matches.length);
     });
@@ -44,7 +44,7 @@ describe("Class query", function () {
     it(":declaration", function () {
         var matches = esquery(ast, ":declaratioN");
         assert.includeMembers(matches, [
-          ast.body[0]
+            ast.body[0]
         ]);
         assert.equal(1, matches.length);
     });
@@ -52,16 +52,16 @@ describe("Class query", function () {
     it(":pattern", function () {
         var matches = esquery(ast, ":paTTern");
         assert.includeMembers(matches, [
-          ast.body[0].id,
-          ast.body[0].body.body[0].expression,
-          ast.body[0].body.body[0].expression.left,
-          ast.body[0].body.body[0].expression.left.elements[0],
-          ast.body[0].body.body[0].expression.right,
-          ast.body[0].body.body[0].expression.right.body,
-          ast.body[0].body.body[1].expression,
-          ast.body[0].body.body[2].expression,
-          ast.body[0].body.body[3].expression,
-          ast.body[0].body.body[3].expression.expressions[0]
+            ast.body[0].id,
+            ast.body[0].body.body[0].expression,
+            ast.body[0].body.body[0].expression.left,
+            ast.body[0].body.body[0].expression.left.elements[0],
+            ast.body[0].body.body[0].expression.right,
+            ast.body[0].body.body[0].expression.right.body,
+            ast.body[0].body.body[1].expression,
+            ast.body[0].body.body[2].expression,
+            ast.body[0].body.body[3].expression,
+            ast.body[0].body.body[3].expression.expressions[0]
         ]);
         assert.equal(10, matches.length);
     });

--- a/tests/queryComplex.js
+++ b/tests/queryComplex.js
@@ -1,39 +1,39 @@
-import esquery from "../esquery.js";
-import conditional from "./fixtures/conditional.js";
-import simpleProgram from "./fixtures/simpleProgram.js";
+import esquery from '../esquery.js';
+import conditional from './fixtures/conditional.js';
+import simpleProgram from './fixtures/simpleProgram.js';
 
-describe("Complex selector query", function () {
+describe('Complex selector query', function () {
 
-    it("two types child", function () {
-        var matches = esquery(conditional, "IfStatement > BinaryExpression");
+    it('two types child', function () {
+        const matches = esquery(conditional, 'IfStatement > BinaryExpression');
         assert.includeMembers(matches, [
             conditional.body[0].test
         ]);
     });
 
-    it("three types child", function () {
-        var matches = esquery(conditional, "IfStatement > BinaryExpression > Identifier");
+    it('three types child', function () {
+        const matches = esquery(conditional, 'IfStatement > BinaryExpression > Identifier');
         assert.includeMembers(matches, [
             conditional.body[0].test.left
         ]);
     });
 
-    it("two types descendant", function () {
-        var matches = esquery(conditional, "IfStatement BinaryExpression");
+    it('two types descendant', function () {
+        const matches = esquery(conditional, 'IfStatement BinaryExpression');
         assert.includeMembers(matches, [
             conditional.body[0].test
         ]);
     });
 
-    it("two types sibling", function () {
-        var matches = esquery(simpleProgram, "VariableDeclaration ~ IfStatement");
+    it('two types sibling', function () {
+        const matches = esquery(simpleProgram, 'VariableDeclaration ~ IfStatement');
         assert.includeMembers(matches, [
             simpleProgram.body[3]
         ]);
     });
 
-    it("two types adjacent", function () {
-        var matches = esquery(simpleProgram, "VariableDeclaration + ExpressionStatement");
+    it('two types adjacent', function () {
+        const matches = esquery(simpleProgram, 'VariableDeclaration + ExpressionStatement');
         assert.includeMembers(matches, [
             simpleProgram.body[2]
         ]);

--- a/tests/queryCompound.js
+++ b/tests/queryCompound.js
@@ -1,17 +1,17 @@
-import esquery from "../esquery.js";
-import conditional from "./fixtures/conditional.js";
+import esquery from '../esquery.js';
+import conditional from './fixtures/conditional.js';
 
-describe("Compound query", function () {
+describe('Compound query', function () {
 
-    it("two attributes", function () {
-        var matches = esquery(conditional, '[left.name="x"][right.value=1]');
+    it('two attributes', function () {
+        const matches = esquery(conditional, '[left.name="x"][right.value=1]');
         assert.includeMembers(matches, [
             conditional.body[0].test
         ]);
     });
 
-    it("type and pseudo", function () {
-        var matches = esquery(conditional, '[left.name="x"]:matches(*)');
+    it('type and pseudo', function () {
+        const matches = esquery(conditional, '[left.name="x"]:matches(*)');
         assert.includeMembers(matches, [
             conditional.body[0].test
         ]);

--- a/tests/queryDescendant.js
+++ b/tests/queryDescendant.js
@@ -1,10 +1,10 @@
-import esquery from "../esquery.js";
-import conditional from "./fixtures/conditional.js";
+import esquery from '../esquery.js';
+import conditional from './fixtures/conditional.js';
 
-describe("Pseudo matches query", function () {
+describe('Pseudo matches query', function () {
 
-    it("conditional matches", function () {
-        var matches = esquery(conditional, "Program IfStatement");
+    it('conditional matches', function () {
+        const matches = esquery(conditional, 'Program IfStatement');
         assert.includeMembers(matches, [
             conditional.body[0],
             conditional.body[1],
@@ -12,14 +12,14 @@ describe("Pseudo matches query", function () {
         ]);
     });
 
-    it("#8: descendant selector includes ancestor in search", function() {
-        var matches = esquery(conditional, "Identifier[name=x]");
+    it('#8: descendant selector includes ancestor in search', function() {
+        let matches = esquery(conditional, 'Identifier[name=x]');
         assert.equal(4, matches.length);
-        matches = esquery(conditional, "Identifier [name=x]");
+        matches = esquery(conditional, 'Identifier [name=x]');
         assert.equal(0, matches.length);
-        matches = esquery(conditional, "BinaryExpression [name=x]");
+        matches = esquery(conditional, 'BinaryExpression [name=x]');
         assert.equal(2, matches.length);
-        matches = esquery(conditional, "AssignmentExpression [name=x]");
+        matches = esquery(conditional, 'AssignmentExpression [name=x]');
         assert.equal(1, matches.length);
     });
 

--- a/tests/queryField.js
+++ b/tests/queryField.js
@@ -1,11 +1,11 @@
-import esquery from "../esquery.js";
-import conditional from "./fixtures/conditional.js";
-import simpleProgram from "./fixtures/simpleProgram.js";
+import esquery from '../esquery.js';
+import conditional from './fixtures/conditional.js';
+import simpleProgram from './fixtures/simpleProgram.js';
 
-describe("Field query", function () {
+describe('Field query', function () {
 
-    it("single field", function () {
-        var matches = esquery(conditional, ".test");
+    it('single field', function () {
+        const matches = esquery(conditional, '.test');
         assert.includeMembers(matches, [
             conditional.body[0].test,
             conditional.body[1].test,
@@ -13,16 +13,16 @@ describe("Field query", function () {
         ]);
     });
 
-    it("field sequence", function () {
-        var matches = esquery(simpleProgram, ".declarations.init");
+    it('field sequence', function () {
+        const matches = esquery(simpleProgram, '.declarations.init');
         assert.includeMembers(matches, [
             simpleProgram.body[0].declarations[0].init,
             simpleProgram.body[1].declarations[0].init
         ]);
     });
 
-    it("field sequence (long)", function () {
-        var matches = esquery(simpleProgram, ".body.declarations.init");
+    it('field sequence (long)', function () {
+        const matches = esquery(simpleProgram, '.body.declarations.init');
         assert.includeMembers(matches, [
             simpleProgram.body[0].declarations[0].init,
             simpleProgram.body[1].declarations[0].init

--- a/tests/queryHas.js
+++ b/tests/queryHas.js
@@ -1,30 +1,30 @@
-import esquery from "../esquery.js";
-import conditional from "./fixtures/conditional.js";
+import esquery from '../esquery.js';
+import conditional from './fixtures/conditional.js';
 
-describe("Parent selector query", function () {
+describe('Parent selector query', function () {
 
-    it("conditional", function () {
-        var matches = esquery(conditional, 'ExpressionStatement:has([name="foo"][type="Identifier"])');
+    it('conditional', function () {
+        const matches = esquery(conditional, 'ExpressionStatement:has([name="foo"][type="Identifier"])');
         assert.equal(1, matches.length);
     });
 
-    it("one of", function () {
-        var matches = esquery(conditional, 'IfStatement:has(LogicalExpression [name="foo"], LogicalExpression [name="x"])');
+    it('one of', function () {
+        const matches = esquery(conditional, 'IfStatement:has(LogicalExpression [name="foo"], LogicalExpression [name="x"])');
         assert.equal(1, matches.length);
     });
 
-    it("chaining", function () {
-        var matches = esquery(conditional, 'BinaryExpression:has(Identifier[name="x"]):has(Literal[value="test"])');
+    it('chaining', function () {
+        const matches = esquery(conditional, 'BinaryExpression:has(Identifier[name="x"]):has(Literal[value="test"])');
         assert.equal(1, matches.length);
     });
 
-    it("nesting", function () {
-        var matches = esquery(conditional, 'Program:has(IfStatement:has(Literal[value=true], Literal[value=false]))');
+    it('nesting', function () {
+        const matches = esquery(conditional, 'Program:has(IfStatement:has(Literal[value=true], Literal[value=false]))');
         assert.equal(1, matches.length);
     });
 
-    it("non-matching", function () {
-        var matches = esquery(conditional, ':has([value="impossible"])');
+    it('non-matching', function () {
+        const matches = esquery(conditional, ':has([value="impossible"])');
         assert.equal(0, matches.length);
     });
 

--- a/tests/queryMatches.js
+++ b/tests/queryMatches.js
@@ -1,37 +1,37 @@
-import esquery from "../esquery.js";
-import conditional from "./fixtures/conditional.js";
-import forLoop from "./fixtures/forLoop.js";
-import simpleFunction from "./fixtures/simpleFunction.js";
-import simpleProgram from "./fixtures/simpleProgram.js";
+import esquery from '../esquery.js';
+import conditional from './fixtures/conditional.js';
+import forLoop from './fixtures/forLoop.js';
+import simpleFunction from './fixtures/simpleFunction.js';
+import simpleProgram from './fixtures/simpleProgram.js';
 
-describe("Pseudo matches query", function () {
+describe('Pseudo matches query', function () {
 
-    it("conditional matches", function () {
-        var matches = esquery(conditional, ":matches(IfStatement)");
+    it('conditional matches', function () {
+        const matches = esquery(conditional, ':matches(IfStatement)');
         assert.includeMembers(matches, [
             conditional.body[0],
             conditional.body[1].alternate
         ]);
     });
 
-    it("for loop matches", function () {
-        var matches = esquery(forLoop, ":matches(BinaryExpression, MemberExpression)");
+    it('for loop matches', function () {
+        const matches = esquery(forLoop, ':matches(BinaryExpression, MemberExpression)');
         assert.includeMembers(matches, [
             forLoop.body[0].test,
             forLoop.body[0].body.body[0].expression.callee
         ]);
     });
 
-    it("simple function matches", function () {
-        var matches = esquery(simpleFunction, ':matches([name="foo"], ReturnStatement)');
+    it('simple function matches', function () {
+        const matches = esquery(simpleFunction, ':matches([name="foo"], ReturnStatement)');
         assert.includeMembers(matches, [
             simpleFunction.body[0].id,
             simpleFunction.body[0].body.body[2]
         ]);
     });
 
-    it("simple program matches", function () {
-        var matches = esquery(simpleProgram, ":matches(AssignmentExpression, BinaryExpression)");
+    it('simple program matches', function () {
+        const matches = esquery(simpleProgram, ':matches(AssignmentExpression, BinaryExpression)');
         assert.includeMembers(matches, [
             simpleProgram.body[2].expression,
             simpleProgram.body[3].consequent.body[0].expression,
@@ -39,8 +39,8 @@ describe("Pseudo matches query", function () {
         ]);
     });
 
-    it("implicit matches", function () {
-        var matches = esquery(simpleProgram, "AssignmentExpression, BinaryExpression, NonExistant");
+    it('implicit matches', function () {
+        const matches = esquery(simpleProgram, 'AssignmentExpression, BinaryExpression, NonExistant');
         assert.includeMembers(matches, [
             simpleProgram.body[2].expression,
             simpleProgram.body[3].consequent.body[0].expression,

--- a/tests/queryNot.js
+++ b/tests/queryNot.js
@@ -1,45 +1,45 @@
-import esquery from "../esquery.js";
-import conditional from "./fixtures/conditional.js";
-import forLoop from "./fixtures/forLoop.js";
-import simpleFunction from "./fixtures/simpleFunction.js";
-import simpleProgram from "./fixtures/simpleProgram.js";
+import esquery from '../esquery.js';
+import conditional from './fixtures/conditional.js';
+import forLoop from './fixtures/forLoop.js';
+import simpleFunction from './fixtures/simpleFunction.js';
+import simpleProgram from './fixtures/simpleProgram.js';
 
-describe("Pseudo matches query", function () {
+describe('Pseudo matches query', function () {
 
-    it("conditional", function () {
-        var matches = esquery(conditional, ":not(Literal)");
+    it('conditional', function () {
+        const matches = esquery(conditional, ':not(Literal)');
         assert.equal(28, matches.length);
     });
 
-    it("for loop", function () {
-        var matches = esquery(forLoop, ':not([name="x"])');
+    it('for loop', function () {
+        const matches = esquery(forLoop, ':not([name="x"])');
         assert.equal(18, matches.length);
     });
 
-    it("simple function", function () {
-        var matches = esquery(simpleFunction, ":not(*)");
+    it('simple function', function () {
+        const matches = esquery(simpleFunction, ':not(*)');
         assert.equal(0, matches.length);
     });
 
-    it("simple program", function () {
-        var matches = esquery(simpleProgram, ":not(Identifier, IfStatement)");
+    it('simple program', function () {
+        const matches = esquery(simpleProgram, ':not(Identifier, IfStatement)');
         assert.equal(15, matches.length);
     });
 
-    it("small program", function () {
-        var program = {
-            type: "Program",
+    it('small program', function () {
+        const program = {
+            type: 'Program',
             body: [{
-                type: "VariableDeclaration",
+                type: 'VariableDeclaration',
                 declarations: [{
-                    type: "VariableDeclarator",
-                    id: {type: "Identifier", name: "x"},
-                    init: {type: "Literal", value: 1, raw: "1"}
+                    type: 'VariableDeclarator',
+                    id: {type: 'Identifier', name: 'x'},
+                    init: {type: 'Literal', value: 1, raw: '1'}
                 }],
-                kind: "var"
+                kind: 'var'
             }]
         };
-        var matches = esquery(program, ":not([value=1])");
+        const matches = esquery(program, ':not([value=1])');
 
         assert.includeMembers(matches, [
             program,

--- a/tests/queryNot.js
+++ b/tests/queryNot.js
@@ -33,8 +33,8 @@ describe('Pseudo matches query', function () {
                 type: 'VariableDeclaration',
                 declarations: [{
                     type: 'VariableDeclarator',
-                    id: {type: 'Identifier', name: 'x'},
-                    init: {type: 'Literal', value: 1, raw: '1'}
+                    id: { type: 'Identifier', name: 'x' },
+                    init: { type: 'Literal', value: 1, raw: '1' }
                 }],
                 kind: 'var'
             }]

--- a/tests/queryPseudoChild.js
+++ b/tests/queryPseudoChild.js
@@ -1,14 +1,14 @@
-import esquery from "../esquery.js";
-import conditional from "./fixtures/conditional.js";
-import conditionalLong from "./fixtures/conditionalLong.js";
-import forLoop from "./fixtures/forLoop.js";
-import simpleFunction from "./fixtures/simpleFunction.js";
-import simpleProgram from "./fixtures/simpleProgram.js";
+import esquery from '../esquery.js';
+import conditional from './fixtures/conditional.js';
+import conditionalLong from './fixtures/conditionalLong.js';
+import forLoop from './fixtures/forLoop.js';
+import simpleFunction from './fixtures/simpleFunction.js';
+import simpleProgram from './fixtures/simpleProgram.js';
 
-describe("Pseudo *-child query", function () {
+describe('Pseudo *-child query', function () {
 
-    it("conditional first child", function () {
-        var matches = esquery(conditional, ":first-child");
+    it('conditional first child', function () {
+        const matches = esquery(conditional, ':first-child');
         assert.includeMembers(matches, [
             conditional.body[0],
             conditional.body[0].consequent.body[0],
@@ -18,8 +18,8 @@ describe("Pseudo *-child query", function () {
         ]);
     });
 
-    it("conditional last child", function () {
-        var matches = esquery(conditional, ":last-child");
+    it('conditional last child', function () {
+        const matches = esquery(conditional, ':last-child');
         assert.includeMembers(matches, [
             conditional.body[1],
             conditional.body[0].consequent.body[0],
@@ -29,58 +29,58 @@ describe("Pseudo *-child query", function () {
         ]);
     });
 
-    it("conditional nth child", function () {
-        var matches = esquery(conditional, ":nth-child(2)");
+    it('conditional nth child', function () {
+        let matches = esquery(conditional, ':nth-child(2)');
         assert.includeMembers(matches, [
             conditional.body[1]
         ]);
 
-        matches = esquery(conditional, ":nth-last-child(2)");
+        matches = esquery(conditional, ':nth-last-child(2)');
         assert.includeMembers(matches, [
             conditional.body[0]
         ]);
     });
 
-    it("conditional nth child (multiple digits)", function () {
-        var matches = esquery(conditionalLong, ":nth-child(10)");
+    it('conditional nth child (multiple digits)', function () {
+        const matches = esquery(conditionalLong, ':nth-child(10)');
         assert.includeMembers(matches, [
             conditionalLong.body[9]
         ]);
     });
 
-    it("conditional nth-last child (multiple digits)", function () {
-        var matches = esquery(conditionalLong, ":nth-last-child(10)");
+    it('conditional nth-last child (multiple digits)', function () {
+        const matches = esquery(conditionalLong, ':nth-last-child(10)');
         assert.includeMembers(matches, [
             conditionalLong.body[1]
         ]);
     });
 
-    it("for loop first child", function () {
-        var matches = esquery(forLoop, ":first-child");
+    it('for loop first child', function () {
+        const matches = esquery(forLoop, ':first-child');
         assert.includeMembers(matches, [
             forLoop.body[0],
             forLoop.body[0].body.body[0]
         ]);
     });
 
-    it("for loop last child", function () {
-        var matches = esquery(forLoop, ":last-child");
+    it('for loop last child', function () {
+        const matches = esquery(forLoop, ':last-child');
         assert.includeMembers(matches, [
             forLoop.body[0],
             forLoop.body[0].body.body[0]
         ]);
     });
 
-    it("for loop nth child", function () {
-        var matches = esquery(forLoop, ":nth-last-child(1)");
+    it('for loop nth child', function () {
+        const matches = esquery(forLoop, ':nth-last-child(1)');
         assert.includeMembers(matches, [
             forLoop.body[0],
             forLoop.body[0].body.body[0]
         ]);
     });
 
-    it("simple function first child", function () {
-        var matches = esquery(simpleFunction, ":first-child");
+    it('simple function first child', function () {
+        const matches = esquery(simpleFunction, ':first-child');
         assert.includeMembers(matches, [
             simpleFunction.body[0],
             simpleFunction.body[0].params[0],
@@ -89,8 +89,8 @@ describe("Pseudo *-child query", function () {
         ]);
     });
 
-    it("simple function last child", function () {
-        var matches = esquery(simpleFunction, ":last-child");
+    it('simple function last child', function () {
+        const matches = esquery(simpleFunction, ':last-child');
         assert.includeMembers(matches, [
             simpleFunction.body[0],
             simpleFunction.body[0].params[1],
@@ -99,27 +99,27 @@ describe("Pseudo *-child query", function () {
         ]);
     });
 
-    it("simple function nth child", function () {
-        var matches = esquery(simpleFunction, ":nth-child(2)");
+    it('simple function nth child', function () {
+        let matches = esquery(simpleFunction, ':nth-child(2)');
         assert.includeMembers(matches, [
             simpleFunction.body[0].params[1],
             simpleFunction.body[0].body.body[1]
         ]);
 
-        matches = esquery(simpleFunction, ":nth-child(3)");
+        matches = esquery(simpleFunction, ':nth-child(3)');
         assert.includeMembers(matches, [
             simpleFunction.body[0].body.body[2]
         ]);
 
-        matches = esquery(simpleFunction, ":nth-last-child(2)");
+        matches = esquery(simpleFunction, ':nth-last-child(2)');
         assert.includeMembers(matches, [
             simpleFunction.body[0].params[0],
             simpleFunction.body[0].body.body[1]
         ]);
     });
 
-    it("simple program first child", function () {
-        var matches = esquery(simpleProgram, ":first-child");
+    it('simple program first child', function () {
+        const matches = esquery(simpleProgram, ':first-child');
         assert.includeMembers(matches, [
             simpleProgram.body[0],
             simpleProgram.body[0].declarations[0],
@@ -128,8 +128,8 @@ describe("Pseudo *-child query", function () {
         ]);
     });
 
-    it("simple program last child", function () {
-        var matches = esquery(simpleProgram, ":last-child");
+    it('simple program last child', function () {
+        const matches = esquery(simpleProgram, ':last-child');
         assert.includeMembers(matches, [
             simpleProgram.body[3],
             simpleProgram.body[0].declarations[0],
@@ -138,18 +138,18 @@ describe("Pseudo *-child query", function () {
         ]);
     });
 
-    it("simple program nth child", function () {
-        var matches = esquery(simpleProgram, ":nth-child(2)");
+    it('simple program nth child', function () {
+        let matches = esquery(simpleProgram, ':nth-child(2)');
         assert.includeMembers(matches, [
             simpleProgram.body[1]
         ]);
 
-        matches = esquery(simpleProgram, ":nth-child(3)");
+        matches = esquery(simpleProgram, ':nth-child(3)');
         assert.includeMembers(matches, [
             simpleProgram.body[2]
         ]);
 
-        matches = esquery(simpleProgram, ":nth-last-child(2)");
+        matches = esquery(simpleProgram, ':nth-last-child(2)');
         assert.includeMembers(matches, [
             simpleProgram.body[2]
         ]);

--- a/tests/querySubject.js
+++ b/tests/querySubject.js
@@ -1,16 +1,16 @@
-import esquery from "../esquery.js";
-import conditional from "./fixtures/conditional.js";
-import forLoop from "./fixtures/forLoop.js";
-import simpleFunction from "./fixtures/simpleFunction.js";
-import simpleProgram from "./fixtures/simpleProgram.js";
+import esquery from '../esquery.js';
+import conditional from './fixtures/conditional.js';
+import forLoop from './fixtures/forLoop.js';
+import simpleFunction from './fixtures/simpleFunction.js';
+import simpleProgram from './fixtures/simpleProgram.js';
 
-import nestedFunctions from "./fixtures/nestedFunctions.js";
-import bigArray from "./fixtures/bigArray.js";
+import nestedFunctions from './fixtures/nestedFunctions.js';
+import bigArray from './fixtures/bigArray.js';
 
-describe("Query subject", function () {
+describe('Query subject', function () {
 
-    it("type subject", function () {
-        var matches = esquery(conditional, "!IfStatement Identifier");
+    it('type subject', function () {
+        const matches = esquery(conditional, '!IfStatement Identifier');
         assert.includeMembers(matches, [
             conditional.body[0],
             conditional.body[1],
@@ -18,16 +18,16 @@ describe("Query subject", function () {
         ]);
     });
 
-    it("* subject", function () {
-        var matches = esquery(forLoop, '!* > [name="foo"]');
+    it('* subject', function () {
+        const matches = esquery(forLoop, '!* > [name="foo"]');
         assert.includeMembers(matches, [
             forLoop.body[0].test.right,
             forLoop.body[0].body.body[0].expression.callee
         ]);
     });
 
-    it(":nth-child subject", function () {
-        var matches = esquery(simpleFunction, '!:nth-child(1) [name="y"]');
+    it(':nth-child subject', function () {
+        const matches = esquery(simpleFunction, '!:nth-child(1) [name="y"]');
         assert.includeMembers(matches, [
             simpleFunction.body[0],
             simpleFunction.body[0].body.body[0],
@@ -35,8 +35,8 @@ describe("Query subject", function () {
         ]);
     });
 
-    it(":nth-last-child subject", function () {
-        var matches = esquery(simpleProgram, '!:nth-last-child(1) [name="y"]');
+    it(':nth-last-child subject', function () {
+        const matches = esquery(simpleProgram, '!:nth-last-child(1) [name="y"]');
         assert.includeMembers(matches, [
             simpleProgram.body[3],
             simpleProgram.body[1].declarations[0],
@@ -44,23 +44,23 @@ describe("Query subject", function () {
         ]);
     });
 
-    it("attribute literal subject", function () {
-        var matches = esquery(simpleProgram, '![test] [name="y"]');
+    it('attribute literal subject', function () {
+        const matches = esquery(simpleProgram, '![test] [name="y"]');
         assert.includeMembers(matches, [
             simpleProgram.body[3]
         ]);
     });
 
-    it("attribute type subject", function () {
-        var matches = esquery(nestedFunctions, '![generator=type(boolean)] > BlockStatement');
+    it('attribute type subject', function () {
+        const matches = esquery(nestedFunctions, '![generator=type(boolean)] > BlockStatement');
         assert.includeMembers(matches, [
             nestedFunctions.body[0],
             nestedFunctions.body[0].body.body[1]
         ]);
     });
 
-    it("attribute regexp subject", function () {
-        var matches = esquery(conditional, '![operator=/=+/] > [name="x"]');
+    it('attribute regexp subject', function () {
+        const matches = esquery(conditional, '![operator=/=+/] > [name="x"]');
         assert.includeMembers(matches, [
             conditional.body[0].test,
             conditional.body[0].alternate.body[0].expression,
@@ -68,59 +68,59 @@ describe("Query subject", function () {
         ]);
     });
 
-    it("field subject", function () {
-        var matches = esquery(forLoop, '!.test');
+    it('field subject', function () {
+        const matches = esquery(forLoop, '!.test');
         assert.includeMembers(matches, [
             forLoop.body[0].test
         ]);
     });
 
-    it(":matches subject", function () {
-        var matches = esquery(forLoop, '!:matches(*) > [name="foo"]');
+    it(':matches subject', function () {
+        const matches = esquery(forLoop, '!:matches(*) > [name="foo"]');
         assert.includeMembers(matches, [
             forLoop.body[0].test.right,
             forLoop.body[0].body.body[0].expression.callee
         ]);
     });
 
-    it(":not subject", function () {
-        var matches = esquery(nestedFunctions, '!:not(BlockStatement) > [name="foo"]');
+    it(':not subject', function () {
+        const matches = esquery(nestedFunctions, '!:not(BlockStatement) > [name="foo"]');
         assert.includeMembers(matches, [
             nestedFunctions.body[0]
         ]);
     });
 
-    it("compound attributes subject", function () {
-        var matches = esquery(conditional, '![left.name="x"][right.value=1]');
+    it('compound attributes subject', function () {
+        const matches = esquery(conditional, '![left.name="x"][right.value=1]');
         assert.includeMembers(matches, [
             conditional.body[0].test
         ]);
     });
 
-    it("descendant right subject", function () {
-        var matches = esquery(forLoop, '* !AssignmentExpression');
+    it('descendant right subject', function () {
+        const matches = esquery(forLoop, '* !AssignmentExpression');
         assert.includeMembers(matches, [
             forLoop.body[0].init
         ]);
     });
 
-    it("child right subject", function () {
-        var matches = esquery(forLoop, '* > !AssignmentExpression');
+    it('child right subject', function () {
+        const matches = esquery(forLoop, '* > !AssignmentExpression');
         assert.includeMembers(matches, [
             forLoop.body[0].init
         ]);
     });
 
-    it("sibling left subject", function () {
-        var matches = esquery(simpleProgram, "!VariableDeclaration ~ IfStatement");
+    it('sibling left subject', function () {
+        const matches = esquery(simpleProgram, '!VariableDeclaration ~ IfStatement');
         assert.includeMembers(matches, [
             simpleProgram.body[0],
             simpleProgram.body[1]
         ]);
     });
 
-    it("sibling right subject", function () {
-        var matches = esquery(simpleProgram, "!VariableDeclaration ~ !IfStatement");
+    it('sibling right subject', function () {
+        const matches = esquery(simpleProgram, '!VariableDeclaration ~ !IfStatement');
         assert.includeMembers(matches, [
             simpleProgram.body[0],
             simpleProgram.body[1],
@@ -128,16 +128,16 @@ describe("Query subject", function () {
         ]);
     });
 
-    it("adjacent right subject", function () {
-        var matches = esquery(simpleProgram, "!VariableDeclaration + !ExpressionStatement");
+    it('adjacent right subject', function () {
+        const matches = esquery(simpleProgram, '!VariableDeclaration + !ExpressionStatement');
         assert.includeMembers(matches, [
             simpleProgram.body[1],
             simpleProgram.body[2]
         ]);
     });
 
-    it("multiple adjacent siblings", function () {
-        var matches = esquery(bigArray, "Identifier + Identifier");
+    it('multiple adjacent siblings', function () {
+        const matches = esquery(bigArray, 'Identifier + Identifier');
         assert.includeMembers(matches, [
             bigArray.body[0].expression.elements[4],
             bigArray.body[0].expression.elements[8]
@@ -145,8 +145,8 @@ describe("Query subject", function () {
         assert.equal(2, matches.length);
     });
 
-    it("multiple siblings", function () {
-        var matches = esquery(bigArray, "Identifier ~ Identifier");
+    it('multiple siblings', function () {
+        const matches = esquery(bigArray, 'Identifier ~ Identifier');
         assert.includeMembers(matches, [
             bigArray.body[0].expression.elements[4],
             bigArray.body[0].expression.elements[7],

--- a/tests/queryType.js
+++ b/tests/queryType.js
@@ -1,29 +1,29 @@
-import esquery from "../esquery.js";
-import conditional from "./fixtures/conditional.js";
-import forLoop from "./fixtures/forLoop.js";
-import simpleFunction from "./fixtures/simpleFunction.js";
-import simpleProgram from "./fixtures/simpleProgram.js";
+import esquery from '../esquery.js';
+import conditional from './fixtures/conditional.js';
+import forLoop from './fixtures/forLoop.js';
+import simpleFunction from './fixtures/simpleFunction.js';
+import simpleProgram from './fixtures/simpleProgram.js';
 
-describe("Type query", function () {
+describe('Type query', function () {
 
-    it("conditional", function () {
-        var matches = esquery(conditional, "Program");
+    it('conditional', function () {
+        let matches = esquery(conditional, 'Program');
         assert.includeMembers(matches, [conditional]);
 
-        matches = esquery(conditional, "IfStatement");
+        matches = esquery(conditional, 'IfStatement');
         assert.includeMembers(matches, [
             conditional.body[0],
             conditional.body[1],
             conditional.body[1].alternate
         ]);
 
-        matches = esquery(conditional, "LogicalExpression");
+        matches = esquery(conditional, 'LogicalExpression');
         assert.includeMembers(matches, [
             conditional.body[1].test,
             conditional.body[1].test.left
         ]);
 
-        matches = esquery(conditional, "ExpressionStatement");
+        matches = esquery(conditional, 'ExpressionStatement');
         assert.includeMembers(matches, [
             conditional.body[0].consequent.body[0],
             conditional.body[0].alternate.body[0],
@@ -32,58 +32,58 @@ describe("Type query", function () {
         ]);
     });
 
-    it("for loop", function () {
-        var matches = esquery(forLoop, "Program");
+    it('for loop', function () {
+        let matches = esquery(forLoop, 'Program');
         assert.includeMembers(matches, [forLoop]);
 
-        matches = esquery(forLoop, "ForStatement");
+        matches = esquery(forLoop, 'ForStatement');
         assert.includeMembers(matches, [
             forLoop.body[0]
         ]);
 
-        matches = esquery(forLoop, "BinaryExpression");
+        matches = esquery(forLoop, 'BinaryExpression');
         assert.includeMembers(matches, [
             forLoop.body[0].test
         ]);
     });
 
-    it("simple function", function () {
-        var matches = esquery(simpleFunction, "Program");
+    it('simple function', function () {
+        let matches = esquery(simpleFunction, 'Program');
         assert.includeMembers(matches, [simpleFunction]);
 
-        matches = esquery(simpleFunction, "VariableDeclaration");
+        matches = esquery(simpleFunction, 'VariableDeclaration');
         assert.includeMembers(matches, [
             simpleFunction.body[0].body.body[0]
         ]);
 
-        matches = esquery(simpleFunction, "FunctionDeclaration");
+        matches = esquery(simpleFunction, 'FunctionDeclaration');
         assert.includeMembers(matches, [
             simpleFunction.body[0]
         ]);
 
-        matches = esquery(simpleFunction, "ReturnStatement");
+        matches = esquery(simpleFunction, 'ReturnStatement');
         assert.includeMembers(matches, [
             simpleFunction.body[0].body.body[2]
         ]);
     });
 
-    it("simple program", function () {
-        var matches = esquery(simpleProgram, "Program");
+    it('simple program', function () {
+        let matches = esquery(simpleProgram, 'Program');
         assert.includeMembers(matches, [simpleProgram]);
 
-        matches = esquery(simpleProgram, "VariableDeclaration");
+        matches = esquery(simpleProgram, 'VariableDeclaration');
         assert.includeMembers(matches, [
             simpleProgram.body[0],
             simpleProgram.body[1]
         ]);
 
-        matches = esquery(simpleProgram, "AssignmentExpression");
+        matches = esquery(simpleProgram, 'AssignmentExpression');
         assert.includeMembers(matches, [
             simpleProgram.body[2].expression,
             simpleProgram.body[3].consequent.body[0].expression
         ]);
 
-        matches = esquery(simpleProgram, "Identifier");
+        matches = esquery(simpleProgram, 'Identifier');
         assert.includeMembers(matches, [
             simpleProgram.body[0].declarations[0].id,
             simpleProgram.body[1].declarations[0].id,
@@ -94,35 +94,35 @@ describe("Type query", function () {
         ]);
     });
 
-    it("# type", function () {
-        var matches = esquery(forLoop, "#Program");
+    it('# type', function () {
+        let matches = esquery(forLoop, '#Program');
         assert.includeMembers(matches, [
             forLoop
         ]);
 
-        matches = esquery(forLoop, "#ForStatement");
+        matches = esquery(forLoop, '#ForStatement');
         assert.includeMembers(matches, [
             forLoop.body[0]
         ]);
 
-        matches = esquery(forLoop, "#BinaryExpression");
+        matches = esquery(forLoop, '#BinaryExpression');
         assert.includeMembers(matches, [
             forLoop.body[0].test
         ]);
     });
 
-    it("case insensitive type", function () {
-        var matches = esquery(forLoop, "Program");
+    it('case insensitive type', function () {
+        let matches = esquery(forLoop, 'Program');
         assert.includeMembers(matches, [
             forLoop
         ]);
 
-        matches = esquery(forLoop, "forStatement");
+        matches = esquery(forLoop, 'forStatement');
         assert.includeMembers(matches, [
             forLoop.body[0]
         ]);
 
-        matches = esquery(forLoop, "binaryexpression");
+        matches = esquery(forLoop, 'binaryexpression');
         assert.includeMembers(matches, [
             forLoop.body[0].test
         ]);

--- a/tests/queryWildcard.js
+++ b/tests/queryWildcard.js
@@ -1,50 +1,50 @@
-import esquery from "../esquery.js";
-import conditional from "./fixtures/conditional.js";
-import forLoop from "./fixtures/forLoop.js";
-import simpleFunction from "./fixtures/simpleFunction.js";
-import simpleProgram from "./fixtures/simpleProgram.js";
+import esquery from '../esquery.js';
+import conditional from './fixtures/conditional.js';
+import forLoop from './fixtures/forLoop.js';
+import simpleFunction from './fixtures/simpleFunction.js';
+import simpleProgram from './fixtures/simpleProgram.js';
 
-describe("Wildcard query", function () {
+describe('Wildcard query', function () {
 
-    it("empty", function () {
-        var matches = esquery(conditional, "");
+    it('empty', function () {
+        const matches = esquery(conditional, '');
         assert.equal(0, matches.length);
     });
 
-    it("conditional", function () {
-        var matches = esquery(conditional, "*");
+    it('conditional', function () {
+        const matches = esquery(conditional, '*');
         assert.equal(35, matches.length);
     });
 
-    it("for loop", function () {
-        var matches = esquery(forLoop, "*");
+    it('for loop', function () {
+        const matches = esquery(forLoop, '*');
         assert.equal(18, matches.length);
     });
 
-    it("simple function", function () {
-        var matches = esquery(simpleFunction, "*");
+    it('simple function', function () {
+        const matches = esquery(simpleFunction, '*');
         assert.equal(17, matches.length);
     });
 
-    it("simple program", function () {
-        var matches = esquery(simpleProgram, "*");
+    it('simple program', function () {
+        const matches = esquery(simpleProgram, '*');
         assert.equal(22, matches.length);
     });
 
-    it("small program", function () {
-        var program = {
-            type: "Program",
+    it('small program', function () {
+        const program = {
+            type: 'Program',
             body: [{
-                type: "VariableDeclaration",
+                type: 'VariableDeclaration',
                 declarations: [{
-                    type: "VariableDeclarator",
-                    id: {type: "Identifier", name: "x"},
-                    init: {type: "Literal", value: 1, raw: "1"}
+                    type: 'VariableDeclarator',
+                    id: {type: 'Identifier', name: 'x'},
+                    init: {type: 'Literal', value: 1, raw: '1'}
                 }],
-                kind: "var"
+                kind: 'var'
             }]
         };
-        var matches = esquery(program, "*");
+        const matches = esquery(program, '*');
 
         assert.includeMembers(matches, [
             program,

--- a/tests/queryWildcard.js
+++ b/tests/queryWildcard.js
@@ -38,8 +38,8 @@ describe('Wildcard query', function () {
                 type: 'VariableDeclaration',
                 declarations: [{
                     type: 'VariableDeclarator',
-                    id: {type: 'Identifier', name: 'x'},
-                    init: {type: 'Literal', value: 1, raw: '1'}
+                    id: { type: 'Identifier', name: 'x' },
+                    init: { type: 'Literal', value: 1, raw: '1' }
                 }],
                 kind: 'var'
             }]

--- a/tests/unknownNodeType.js
+++ b/tests/unknownNodeType.js
@@ -3,10 +3,10 @@ import AST from "./fixtures/unknownNodeTypeAST.js";
 
 describe("Unknown node type", function () {
     it("does not throw", function () {
-      try {
-        esquery(AST, '*');
-      } catch (e) {
-        assert.fail();
-      }
+        try {
+            esquery(AST, '*');
+        } catch (e) {
+            assert.fail();
+        }
     });
 });

--- a/tests/unknownNodeType.js
+++ b/tests/unknownNodeType.js
@@ -1,8 +1,8 @@
-import esquery from "../esquery.js";
-import AST from "./fixtures/unknownNodeTypeAST.js";
+import esquery from '../esquery.js';
+import AST from './fixtures/unknownNodeTypeAST.js';
 
-describe("Unknown node type", function () {
-    it("does not throw", function () {
+describe('Unknown node type', function () {
+    it('does not throw', function () {
         try {
             esquery(AST, '*');
         } catch (e) {


### PR DESCRIPTION
Builds on #84 (and if you want it, on #85 ).

The `indent` rule enforces existing behavior (accompanied by some fixes), while the other rules and accompanying fixes are offered as I find them to be very helpful in making the code more semantic or otherwise easier to read, and, in the case of `const` and `let`, more clear as to intent.

- Enforce current `indent` throughout project
- Apply rules for `prefer-const`, `no-var`, `prefer-destructuring`, `object-shorthand`, and `quotes`
- Prefer for-of
- Prefer spread operator
- Remove else after return
