### PR TITLE
use templates for multiline fixtures

### DIFF
--- a/tests/fixtures/conditional.js
+++ b/tests/fixtures/conditional.js
@@ -1,8 +1,8 @@
 import * as esprima from 'esprima';
 
-const parsed = esprima.parse(
-    'if (x === 1) { foo(); } else { x = 2; }\n' +
-    'if (x == \'test\' && true || x) { y = -1; } else if (false) { y = 1; }'
-);
+const parsed = esprima.parse(`
+    if (x === 1) { foo(); } else { x = 2; }
+    if (x == 'test' && true || x) { y = -1; } else if (false) { y = 1; }
+`);
 
 export default parsed;

--- a/tests/fixtures/conditionalLong.js
+++ b/tests/fixtures/conditionalLong.js
@@ -1,17 +1,17 @@
 import * as esprima from 'esprima';
 
-const parsed = esprima.parse(
-    'if (x === 1) { foo(1); }' +
-    'if (x === 2) { foo(2); }' +
-    'if (x === 3) { foo(3); }' +
-    'if (x === 4) { foo(4); }' +
-    'if (x === 5) { foo(5); }' +
-    'if (x === 6) { foo(6); }' +
-    'if (x === 7) { foo(7); }' +
-    'if (x === 8) { foo(8); }' +
-    'if (x === 9) { foo(9); }' +
-    'if (x === 10) { foo(10); }' +
-    'if (x === 11) { foo(11); }'
-);
+const parsed = esprima.parse(`
+    if (x === 1) { foo(1); }
+    if (x === 2) { foo(2); }
+    if (x === 3) { foo(3); }
+    if (x === 4) { foo(4); }
+    if (x === 5) { foo(5); }
+    if (x === 6) { foo(6); }
+    if (x === 7) { foo(7); }
+    if (x === 8) { foo(8); }
+    if (x === 9) { foo(9); }
+    if (x === 10) { foo(10); }
+    if (x === 11) { foo(11); }
+`);
 
 export default parsed;

--- a/tests/fixtures/literal.js
+++ b/tests/fixtures/literal.js
@@ -1,10 +1,10 @@
 import * as esprima from 'esprima';
 
-const parsed = esprima.parse(
-    'var y = \'\b\f\\n\\r\t\v and just a  back\\slash\';\n' +
-    'var x = 21.35;' +
-    'var z = \'\\z\';' +
-    'var a = \'abc\\z\';'
-);
+const parsed = esprima.parse(`
+    var y = '\b\f\\n\\r\t\v and just a  back\\slash';
+    var x = 21.35;
+    var z = '\\z';
+    var a = 'abc\\z';
+`);
 
 export default parsed;

--- a/tests/fixtures/nestedFunctions.js
+++ b/tests/fixtures/nestedFunctions.js
@@ -1,12 +1,12 @@
 import * as esprima from 'esprima';
 
-const parsed = esprima.parse(
-    'function foo() {\n' +
-    '  var x = 1;\n' +
-    '  function bar() {\n' +
-    '    x = 2;\n' +
-    '  }\n' +
-    '}\n'
-);
+const parsed = esprima.parse(`
+    function foo() {
+      var x = 1;
+      function bar() {
+        x = 2;
+      }
+    }
+`);
 
 export default parsed;

--- a/tests/fixtures/simpleFunction.js
+++ b/tests/fixtures/simpleFunction.js
@@ -1,11 +1,11 @@
 import * as esprima from 'esprima';
 
-const parsed = esprima.parse(
-    'function foo(x, y) {\n' +
-    '  var z = x + y;\n' +
-    '  z++;\n' +
-    '  return z;\n' +
-    '}\n'
-);
+const parsed = esprima.parse(`
+    function foo(x, y) {
+      var z = x + y;
+      z++;
+      return z;
+    }
+`);
 
 export default parsed;

--- a/tests/fixtures/simpleProgram.js
+++ b/tests/fixtures/simpleProgram.js
@@ -1,10 +1,10 @@
 import * as esprima from 'esprima';
 
-const parsed = esprima.parse(
-    'var x = 1;\n' +
-    'var y = \'y\';\n' +
-    'x = x * 2;\n' +
-    'if (y) { y += \'z\'; }\n'
-);
+const parsed = esprima.parse(`
+    var x = 1;
+    var y = 'y';
+    x = x * 2;
+    if (y) { y += 'z'; }
+`);
 
 export default parsed;

--- a/tests/fixtures/switchStatement.js
+++ b/tests/fixtures/switchStatement.js
@@ -1,12 +1,12 @@
 import * as esprima from 'esprima';
 
-const parsed = esprima.parse(
-    'var x = 1;\n' +
-    'switch (x) {\n' +
-    '  case 0: foo1(); break;\n' +
-    '  case 1: foo2(); break;\n' +
-    '  default: x = 1; break;\n' +
-    '}\n'
-);
+const parsed = esprima.parse(`
+    var x = 1;
+    switch (x) {
+      case 0: foo1(); break;
+      case 1: foo2(); break;
+      default: x = 1; break;
+    }
+`);
 
 export default parsed;

--- a/tests/fixtures/whileLoop.js
+++ b/tests/fixtures/whileLoop.js
@@ -1,8 +1,8 @@
 import * as esprima from 'esprima';
 
-const parsed = esprima.parse(
-    'x = 10;\n' +
-    'while (x > 0) { x--; }'
-);
+const parsed = esprima.parse(`
+    x = 10;
+    while (x > 0) { x--; }
+`);
 
 export default parsed;


### PR DESCRIPTION
One more linting change I noticed...

Adding `prefer-template` did not auto-fix for multi-line templates (presumably since leading whitespace can sometimes be significant).

For the tests, the whitespace shouldn't be an issue, I think (and the tests are passing), so I've applied for better readability.