### PR TITLE
Remove `.npmignore` in favor of `files` in `package.json` only

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-grammar.pegjs
-tests
-testRunner.html

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     ]
   },
   "scripts": {
+    "prepublishOnly": "npm run build && npm test",
     "build:parser": "rm parser.js && pegjs --cache --format umd -o \"parser.js\" \"grammar.pegjs\"",
     "build:browser": "rollup -c",
     "build": "npm run build:parser && npm run build:browser",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "module": "dist/esquery.esm.min.js",
   "files": [
     "dist/*.js",
+    "dist/*.map",
     "parser.js",
     "license.txt",
     "README.md"


### PR DESCRIPTION
~- Switch from `files` in `package.json` to `.npmignore` only~
- Remove `.npmignore` in favor of `files` in `package.json` only

~Since there was already an `npmignore` file, I've added things in such a way that `files` in `package.json` was no longer needed.~

In addition, `.map` files will be added to the final npm package (confirmable by `npm publish --dry-run`) so the minified distribution files can indicate the original unminified source (though if you still did want `files`, these could also be added to `files`).