### PR TITLE
jsdocs and minor refactoring

### DIFF
--- a/grammar.pegjs
+++ b/grammar.pegjs
@@ -17,7 +17,9 @@
 }
 
 start
-  = _ ss:selectors _ { return ss.length === 1 ? ss[0] : { type: 'matches', selectors: ss }; }
+  = _ ss:selectors _ {
+    return ss.length === 1 ? ss[0] : { type: 'matches', selectors: ss };
+  }
   / _ { return void 0; }
 
 _ = " "*
@@ -41,7 +43,7 @@ selector
 
 sequence
   = subject:"!"? as:atom+ {
-    var b = as.length === 1 ? as[0] : { type: 'compound', selectors: as };
+    const b = as.length === 1 ? as[0] : { type: 'compound', selectors: as };
     if(subject) b.subject = true;
     return b;
   }
@@ -76,7 +78,7 @@ attr
     number
       = a:([0-9]* ".")? b:[0-9]+ {
         // Can use `a.flat().join('')` once supported
-        var leadingDecimals = a ? [].concat.apply([], a).join('') : '';
+        const leadingDecimals = a ? [].concat.apply([], a).join('') : '';
         return { type: 'literal', value: parseFloat(leadingDecimals + b.join('')) };
       }
     path = i:identifierName { return { type: 'literal', value: i }; }

--- a/parser.js
+++ b/parser.js
@@ -147,7 +147,9 @@
         peg$startRuleFunctions = { start: peg$parsestart },
         peg$startRuleFunction  = peg$parsestart,
 
-        peg$c0 = function(ss) { return ss.length === 1 ? ss[0] : { type: 'matches', selectors: ss }; },
+        peg$c0 = function(ss) {
+            return ss.length === 1 ? ss[0] : { type: 'matches', selectors: ss };
+          },
         peg$c1 = function() { return void 0; },
         peg$c2 = " ",
         peg$c3 = peg$literalExpectation(" ", false),
@@ -177,7 +179,7 @@
         peg$c21 = "!",
         peg$c22 = peg$literalExpectation("!", false),
         peg$c23 = function(subject, as) {
-            var b = as.length === 1 ? as[0] : { type: 'compound', selectors: as };
+            const b = as.length === 1 ? as[0] : { type: 'compound', selectors: as };
             if(subject) b.subject = true;
             return b;
           },
@@ -224,7 +226,7 @@
         peg$c60 = peg$classExpectation([["0", "9"]], false, false),
         peg$c61 = function(a, b) {
                 // Can use `a.flat().join('')` once supported
-                var leadingDecimals = a ? [].concat.apply([], a).join('') : '';
+                const leadingDecimals = a ? [].concat.apply([], a).join('') : '';
                 return { type: 'literal', value: parseFloat(leadingDecimals + b.join('')) };
               },
         peg$c62 = function(i) { return { type: 'literal', value: i }; },

--- a/tests/match.js
+++ b/tests/match.js
@@ -57,18 +57,4 @@ describe('match', function () {
                 value: { type: 'foobar' } });
         }, Error);
     });
-
-    // Can remove need for this if remove `subjects`' `hasOwnProperty`
-    //  check in favor of for-of (Node >=6.9.2) or use `Object.keys`
-    it('selector with non-own properties', function () {
-        assert.throws(function () {
-            function Selector () {}
-            Selector.prototype.inheritedMethod = function () {};
-            const sel = new Selector();
-            sel.type = 'class';
-            sel.name = 'badName';
-            sel.value = { type: 'foobar' };
-            esquery.match(ast, sel);
-        }, Error);
-    });
 });


### PR DESCRIPTION
- Docs: Add jsdoc annotations
- Refactoring: Change internally-used constants to strings for simpler enum-like type referencing in jsdocs
- Refactoring: Switch from `hasOwnProperty` check (with test) to Object.entries + for..of loop
- Refactoring: Prefer spread operator over `apply`
- Refactoring: Use `const` in pegjs