### PR TITLE
feat: introduce rollup-plugin-babel to maintain legacy node support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": [
+      "@babel/env"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
     "query"
   ],
   "devDependencies": {
+    "@babel/core": "^7.9.0",
+    "@babel/preset-env": "7.8.7",
+    "rollup-plugin-babel": "^4.4.0",
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-json": "^4.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
@@ -65,9 +68,6 @@
     "rollup-plugin-terser": "^5.2.0"
   },
   "license": "BSD-3-Clause",
-  "engines": {
-    "node": ">=8.0"
-  },
   "dependencies": {
     "estraverse": "^5.0.0"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,6 +3,7 @@ import { terser } from 'rollup-plugin-terser';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
+import babel from 'rollup-plugin-babel';
 
 /**
  * @external RollupConfig
@@ -30,7 +31,8 @@ function getRollupObject ({ minifying, format = 'umd' } = {}) {
         plugins: [
             json(),
             nodeResolve(),
-            commonjs()
+            commonjs(),
+            babel({ exclude: 'node_modules/**' })
         ]
     };
     if (minifying) {


### PR DESCRIPTION
This patch pipes the build process through babel, ensuring the
resulting output can still be used in all of the environments
supported by v1.x of esquery.