### PR TITLE
add esquery.traverse method

### DIFF
--- a/esquery.js
+++ b/esquery.js
@@ -360,16 +360,16 @@ function traverse(ast, selector, visitor) {
                 if (altSubjects.length) {
                     for (let i = 0, l = altSubjects.length; i < l; ++i) {
                         if (matches(node, altSubjects[i], ancestry)) {
-                            visitor(node, parent, ancestry.slice());
+                            visitor(node, parent, ancestry);
                         }
                         for (let k = 0, m = ancestry.length; k < m; ++k) {
                             if (matches(ancestry[k], altSubjects[i], ancestry.slice(k + 1))) {
-                                visitor(ancestry[k], parent, ancestry.slice());
+                                visitor(ancestry[k], parent, ancestry);
                             }
                         }
                     }
                 } else {
-                    visitor(node, parent, ancestry.slice());
+                    visitor(node, parent, ancestry);
                 }
             }
         },

--- a/esquery.js
+++ b/esquery.js
@@ -363,8 +363,9 @@ function traverse(ast, selector, visitor) {
                             visitor(node, parent, ancestry);
                         }
                         for (let k = 0, m = ancestry.length; k < m; ++k) {
-                            if (matches(ancestry[k], altSubjects[i], ancestry.slice(k + 1))) {
-                                visitor(ancestry[k], parent, ancestry);
+                            const succeedingAncestry = ancestry.slice(k + 1);
+                            if (matches(ancestry[k], altSubjects[i], succeedingAncestry)) {
+                                visitor(ancestry[k], parent, succeedingAncestry);
                             }
                         }
                     }

--- a/tests/traverse.js
+++ b/tests/traverse.js
@@ -10,7 +10,7 @@ describe('traverse', function () {
         esquery.traverse(conditional, selector, (match, parent, ancestry) => {
             parents.push(parent);
             matches.push(match);
-            ancestries.push(ancestry);
+            ancestries.push(ancestry.slice());
         });
         assert.deepEqual(matches, [
             conditional.body[0],

--- a/tests/traverse.js
+++ b/tests/traverse.js
@@ -1,0 +1,35 @@
+import esquery from '../esquery.js';
+import conditional from './fixtures/conditional.js';
+
+describe('traverse', function () {
+    it('iterates matches', function () {
+        const matches = [];
+        const parents = [];
+        const ancestries = [];
+        const selector = esquery.parse(':matches(IfStatement)');
+        esquery.traverse(conditional, selector, (match, parent, ancestry) => {
+            parents.push(parent);
+            matches.push(match);
+            ancestries.push(ancestry);
+        });
+        assert.includeMembers(matches, [
+            conditional.body[0],
+            conditional.body[1],
+            conditional.body[1].alternate
+        ]);
+        assert.includeMembers(parents, [
+            conditional,
+            conditional.body[1]
+        ]);
+        assert.includeMembers(ancestries[0], [
+            conditional
+        ]);
+        assert.includeMembers(ancestries[1], [
+            conditional
+        ]);
+        assert.includeMembers(ancestries[2], [
+            conditional.body[1],
+            conditional
+        ]);
+    });
+});

--- a/tests/traverse.js
+++ b/tests/traverse.js
@@ -12,24 +12,23 @@ describe('traverse', function () {
             matches.push(match);
             ancestries.push(ancestry);
         });
-        assert.includeMembers(matches, [
+        assert.deepEqual(matches, [
             conditional.body[0],
             conditional.body[1],
             conditional.body[1].alternate
         ]);
-        assert.includeMembers(parents, [
+        assert.deepEqual(parents, [
+            conditional,
             conditional,
             conditional.body[1]
         ]);
-        assert.includeMembers(ancestries[0], [
-            conditional
-        ]);
-        assert.includeMembers(ancestries[1], [
-            conditional
-        ]);
-        assert.includeMembers(ancestries[2], [
-            conditional.body[1],
-            conditional
+        assert.deepEqual(ancestries, [
+            [conditional],
+            [conditional],
+            [
+                conditional.body[1],
+                conditional
+            ]
         ]);
     });
 });


### PR DESCRIPTION
This closes #45 as it is a rebased version on `master` (with added jsdoc).

Although it was already passing all tests with 100% coverage after rebasing (since the new function was already being used internally), I added a dedicated testing file with a basic check that it is receiving back the expected arguments.