### PR TITLE
- npm: Update dep. estraverse and devDeps; fixes #101

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,27 +52,27 @@
   ],
   "devDependencies": {
     "@babel/core": "^7.9.0",
-    "@babel/preset-env": "^7.9.0",
+    "@babel/preset-env": "^7.9.5",
     "@babel/register": "^7.9.0",
-    "@rollup/plugin-commonjs": "^11.0.2",
+    "@rollup/plugin-commonjs": "^11.1.0",
     "@rollup/plugin-json": "^4.0.2",
-    "@rollup/plugin-node-resolve": "^7.1.1",
+    "@rollup/plugin-node-resolve": "^7.1.3",
     "babel-plugin-transform-es2017-object-entries": "0.0.5",
     "chai": "^4.2.0",
     "eslint": "^6.8.0",
     "esprima": "~4.0.1",
     "mocha": "^7.1.1",
-    "nyc": "^15.0.0",
+    "nyc": "^15.0.1",
     "pegjs": "~0.10.0",
-    "rollup": "^1.32.0",
+    "rollup": "^1.32.1",
     "rollup-plugin-babel": "^4.4.0",
-    "rollup-plugin-terser": "^5.2.0"
+    "rollup-plugin-terser": "^5.3.0"
   },
   "license": "BSD-3-Clause",
   "engines": {
     "node": ">=0.10"
   },
   "dependencies": {
-    "estraverse": "^5.0.0"
+    "estraverse": "^5.1.0"
   }
 }


### PR DESCRIPTION
Fixes #101 .

Note that this doesn't perform a major update to Rollup 2.

(Despite the fact that the new Travis which only builds with Node 10+ should work against Rollup 2, the Rollup plugins give peer dep. warnings as they haven't yet been updated to confirm their support of Rollup 2. This has been reported in a number of issues such as https://github.com/rollup/plugins/issues/285 , but the issues have been closed, with the project indicating it is a known issue. Though the plugins seem to work, it is probably safer to wait for the official review.)
