### PR TITLE
expose lite build without dependencies bundled

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -56,10 +56,8 @@ function getRollupObject ({ minifying, format = 'umd', lite } = {}) {
 export default [
     getRollupObject({ minifying: true, format: 'umd' }),
     getRollupObject({ minifying: false, format: 'umd' }),
-    getRollupObject({ minifying: true, format: 'umd', lite: true }),
-    getRollupObject({ minifying: false, format: 'umd', lite: true }),
     getRollupObject({ minifying: true, format: 'esm' }),
     getRollupObject({ minifying: false, format: 'esm' }),
-    getRollupObject({ minifying: true, format: 'esm', lite: true }),
-    getRollupObject({ minifying: false, format: 'esm', lite: true })
+    getRollupObject({ minifying: true, format: 'umd', lite: true }),
+    getRollupObject({ minifying: false, format: 'umd', lite: true })
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -56,8 +56,10 @@ function getRollupObject ({ minifying, format = 'umd', lite } = {}) {
 export default [
     getRollupObject({ minifying: true, format: 'umd' }),
     getRollupObject({ minifying: false, format: 'umd' }),
+    getRollupObject({ minifying: true, format: 'umd', lite: true }),
+    getRollupObject({ minifying: false, format: 'umd', lite: true }),
     getRollupObject({ minifying: true, format: 'esm' }),
     getRollupObject({ minifying: false, format: 'esm' }),
-    getRollupObject({ minifying: true, format: 'umd', lite: true }),
-    getRollupObject({ minifying: false, format: 'umd', lite: true })
+    getRollupObject({ minifying: true, format: 'esm', lite: true }),
+    getRollupObject({ minifying: false, format: 'esm', lite: true })
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 
 import babel from 'rollup-plugin-babel';
+import packageJson from './package.json';
 
 /**
  * @external RollupConfig
@@ -45,7 +46,7 @@ function getRollupObject ({ minifying, format = 'umd', lite } = {}) {
         ]
     };
     if (lite) {
-        nonMinified.external = ['estraverse'];
+        nonMinified.external = Object.keys(packageJson.dependencies);
     }
     if (minifying) {
         nonMinified.plugins.push(terser());

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,18 +16,26 @@ import babel from 'rollup-plugin-babel';
  * @param {PlainObject} [config= {}]
  * @param {boolean} [config.minifying=false]
  * @param {string} [config.format='umd']
+ * @param {boolean} [config.lite=false]
  * @returns {external:RollupConfig}
  */
-function getRollupObject ({ minifying, format = 'umd' } = {}) {
+function getRollupObject ({ minifying, format = 'umd', lite } = {}) {
     const nonMinified = {
         input: 'esquery.js',
         output: {
             format,
             sourcemap: minifying,
-            file: `dist/esquery${
-                format === 'umd' ? '' : `.${format}`
-            }${minifying ? '.min' : ''}.js`,
-            name: 'esquery'
+            file: [
+                'dist/esquery',
+                lite ? '.lite' : '',
+                format === 'umd' ? '' : `.${format}`,
+                minifying ? '.min' : '',
+                '.js'
+            ].join(''),
+            name: 'esquery',
+            globals: {
+                estraverse: 'estraverse'
+            }
         },
         plugins: [
             json(),
@@ -36,6 +44,9 @@ function getRollupObject ({ minifying, format = 'umd' } = {}) {
             babel()
         ]
     };
+    if (lite) {
+        nonMinified.external = ['estraverse'];
+    }
     if (minifying) {
         nonMinified.plugins.push(terser());
     }
@@ -46,5 +57,7 @@ export default [
     getRollupObject({ minifying: true, format: 'umd' }),
     getRollupObject({ minifying: false, format: 'umd' }),
     getRollupObject({ minifying: true, format: 'esm' }),
-    getRollupObject({ minifying: false, format: 'esm' })
+    getRollupObject({ minifying: false, format: 'esm' }),
+    getRollupObject({ minifying: true, format: 'umd', lite: true }),
+    getRollupObject({ minifying: false, format: 'umd', lite: true })
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,7 +20,7 @@ import packageJson from './package.json';
  * @param {boolean} [config.lite=false]
  * @returns {external:RollupConfig}
  */
-function getRollupObject ({ minifying, format = 'umd', lite } = {}) {
+function getRollupObject ({ minifying = false, format = 'umd', lite = false } = {}) {
     const nonMinified = {
         input: 'esquery.js',
         output: {


### PR DESCRIPTION
This is a first pass at creating a new build artifact without the `estraverse` dependency being bundled. See https://github.com/estools/esquery/issues/104 for details.

Fixes:
- https://github.com/estools/esquery/issues/104

Allows workarounds for: 
- https://github.com/estools/esquery/issues/67
- https://github.com/estools/esquery/pull/57

I've left the current main entrypoint as `esquery.min.js`, but it might make sense to make `lite` the entry point instead.

Alternatively, if the current approach in the PR is too messy, I could alter it instead to make this a simple npm module alongside the build (so if required via Node, it would use the source and regular requires, but the dist would still be there for direct usage). I would wager a guess that the majority use case for this library is via Node, so this shouldn't impact a large amount of people, but would still probably necessitate a breaking change semver update.

Let me know your thoughts and where I should take this PR.

P.S.: Love the library! ❤️ 