### PR TITLE
disallow empty attribute names in query language

### DIFF
--- a/grammar.pegjs
+++ b/grammar.pegjs
@@ -59,7 +59,7 @@ attr
   = "[" _ v:attrValue _ "]" { return v; }
   attrOps = a:[><!]? "=" { return (a || '') + '='; } / [><]
   attrEqOps = a:"!"? "="  { return (a || '') + '='; }
-  attrName = i:(identifierName / ".")+ { return i.join(''); }
+  attrName = a:identifierName as:("." identifierName)* { return [a, ...as.reduce((acc, val) => acc.concat(val), [])].join(''); }
   attrValue
     = name:attrName _ op:attrEqOps _ value:(type / regex) {
       return { type: 'attribute', name: name, operator: op, value: value };

--- a/grammar.pegjs
+++ b/grammar.pegjs
@@ -59,7 +59,9 @@ attr
   = "[" _ v:attrValue _ "]" { return v; }
   attrOps = a:[><!]? "=" { return (a || '') + '='; } / [><]
   attrEqOps = a:"!"? "="  { return (a || '') + '='; }
-  attrName = a:identifierName as:("." identifierName)* { return [a, ...as.reduce((acc, val) => acc.concat(val), [])].join(''); }
+  attrName = a:identifierName as:("." identifierName)* {
+    return [].concat.apply([a], as).join('');
+  }
   attrValue
     = name:attrName _ op:attrEqOps _ value:(type / regex) {
       return { type: 'attribute', name: name, operator: op, value: value };

--- a/tests/queryAttribute.js
+++ b/tests/queryAttribute.js
@@ -57,14 +57,6 @@ describe('Attribute query', function () {
         ]);
     });
 
-    // Not sure what AST would be producing an empty string, so
-    //  just checking this acceptable grammar doesn't fail and is
-    //  covered.
-    it('literal with empty string and dot', function () {
-        const matches = esquery(literal, 'Literal[.value=\'abc\']');
-        assert.lengthOf(matches, 0);
-    });
-
     it('literal with backslashes', function () {
         const matches = esquery(literal, 'Literal[value="\\z"]');
         assert.includeMembers(matches, [


### PR DESCRIPTION
Currently, an attribute name can be any sequence of identifiers and dots. For example, the parser will except a selector like:

```
[...hi..hello]
```

The getPath function will probably end up returning undefined in any case when it indexes an object using an empty string.

This pull request modifies the attribute name rule to only accept identifiers separated by exactly one dot.

The resulting array from the rule is flattened using the array reduce function. I noticed a comment further down in the grammar that seemed to indicate that the array flat() function is not supported. If it is supported, the transformation can be simplified to 
```js
return [a, ...as.flat()].join('');
```

It seems like there's a unit test that expects the parser to accept attribute names with a leading dot. I'm not sure what the purpose of this is since the getPath function will always return undefined in this case, but if this is the intended behavior then the grammar rule can easily be modified to accept it.