### PR TITLE
Add support for custom visitor keys.

### DIFF
--- a/esquery.js
+++ b/esquery.js
@@ -239,27 +239,25 @@ function matches(node, selector, ancestry, options) {
 
 /**
  * Get visitor keys of a given node.
- * @param {external:AST} node node The AST node to get keys.
+ * @param {external:AST} node The AST node to get keys.
  * @param {ESQueryOptions|undefined} options
  * @returns {string[]} Visitor keys of the node.
  */
 function getVisitorKeys(node, options) {
     const nodeType = node.type;
-    let candidates;
     if (options && options.visitorKeys && options.visitorKeys[nodeType]) {
-        candidates = options.visitorKeys[nodeType];
-    } else {
-        candidates = estraverse.VisitorKeys[nodeType];
+        return options.visitorKeys[nodeType];
     }
-    if(!candidates) {
-        if (options && typeof options.fallback === 'function') {
-            candidates = options.fallback(node);
-        } else {
-            // 'iteration' fallback
-            candidates = Object.keys(node);
-        }
+    if(estraverse.VisitorKeys[nodeType]) {
+        return estraverse.VisitorKeys[nodeType];
     }
-    return candidates;
+    if (options && typeof options.fallback === 'function') {
+        return options.fallback(node);
+    }
+    // 'iteration' fallback
+    return Object.keys(node).filter(function (key) {
+        return key !== 'type';
+    });
 }
 
 

--- a/esquery.js
+++ b/esquery.js
@@ -248,7 +248,7 @@ function getVisitorKeys(node, options) {
     if (options && options.visitorKeys && options.visitorKeys[nodeType]) {
         return options.visitorKeys[nodeType];
     }
-    if(estraverse.VisitorKeys[nodeType]) {
+    if (estraverse.VisitorKeys[nodeType]) {
         return estraverse.VisitorKeys[nodeType];
     }
     if (options && typeof options.fallback === 'function') {

--- a/tests/fixtures/customNodes.js
+++ b/tests/fixtures/customNodes.js
@@ -1,0 +1,32 @@
+export default {
+    type: 'CustomRoot',
+    list: [
+        {
+            type: 'CustomChild',
+            name: 'one',
+            sublist: [{ type: 'CustomGrandChild' }],
+        },
+        {
+            type: 'CustomChild',
+            name: 'two',
+            sublist: [],
+        },
+        {
+            type: 'CustomChild',
+            name: 'three',
+            sublist: [
+                { type: 'CustomGrandChild' },
+                { type: 'CustomGrandChild' },
+            ],
+        },
+        {
+            type: 'CustomChild',
+            name: 'four',
+            sublist: [
+                { type: 'CustomGrandChild' },
+                { type: 'CustomGrandChild' },
+                { type: 'CustomGrandChild' },
+            ],
+        },
+    ],
+};

--- a/tests/matches.js
+++ b/tests/matches.js
@@ -2,6 +2,7 @@ import esquery from '../esquery.js';
 import forLoop from './fixtures/forLoop.js';
 import simpleProgram from './fixtures/simpleProgram.js';
 import conditional from './fixtures/conditional.js';
+import customNodes from './fixtures/customNodes.js';
 
 describe('matches', function () {
     it('falsey node', function () {
@@ -130,6 +131,88 @@ describe('matches', function () {
                 conditional.body[1],
                 selector,
                 conditional.body
+            );
+        });
+    });
+});
+
+describe('matches with custom AST and custom visitor keys', function () {
+    it('adjacent/sibling', function () {
+        const options = {
+            visitorKeys: {
+                CustomRoot: ['list'],
+                CustomChild: ['sublist'],
+                CustomGrandChild: []
+            }
+        };
+        let selector = esquery.parse('CustomChild + CustomChild');
+        assert.doesNotThrow(() => {
+            esquery.matches(
+                customNodes.list[1],
+                selector,
+                [customNodes],
+                options
+            );
+        });
+
+        selector = esquery.parse('CustomChild ~ CustomChild');
+        assert.doesNotThrow(() => {
+            esquery.matches(
+                customNodes.list[1],
+                selector,
+                [customNodes],
+                options
+            );
+        });
+    });
+});
+
+describe('matches with custom AST and fallback option', function () {
+    it('adjacent/sibling', function () {
+        const options = {
+            fallback (node) {
+                return node.type === 'CustomRoot' ? ['list'] : node.type === 'CustomChild' ? ['sublist'] : [];
+            }
+        };
+        let selector = esquery.parse('CustomChild + CustomChild');
+        assert.doesNotThrow(() => {
+            esquery.matches(
+                customNodes.list[1],
+                selector,
+                [customNodes],
+                options
+            );
+        });
+
+        selector = esquery.parse('CustomChild ~ CustomChild');
+        assert.doesNotThrow(() => {
+            esquery.matches(
+                customNodes.list[1],
+                selector,
+                [customNodes],
+                options
+            );
+        });
+    });
+});
+
+describe('matches with custom AST and default fallback', function () {
+    it('adjacent/sibling', function () {
+        let selector = esquery.parse('CustomChild + CustomChild');
+        assert.doesNotThrow(() => {
+            esquery.matches(
+                customNodes.list[1],
+                selector,
+                [customNodes],
+            );
+        });
+
+        selector = esquery.parse('CustomChild ~ CustomChild');
+        assert.doesNotThrow(() => {
+            esquery.matches(
+                customNodes.list[1],
+                selector,
+                [customNodes],
             );
         });
     });

--- a/tests/querySubject.js
+++ b/tests/querySubject.js
@@ -6,6 +6,7 @@ import simpleProgram from './fixtures/simpleProgram.js';
 
 import nestedFunctions from './fixtures/nestedFunctions.js';
 import bigArray from './fixtures/bigArray.js';
+import customNodes from './fixtures/customNodes.js';
 
 describe('Query subject', function () {
 
@@ -153,5 +154,49 @@ describe('Query subject', function () {
             bigArray.body[0].expression.elements[8]
         ]);
         assert.equal(3, matches.length);
+    });
+});
+
+describe('Query subject with custom ast', function () {
+    const visitorKeys = {
+        CustomRoot: ['list'],
+        CustomChild: ['sublist'],
+        CustomGrandChild: []
+    };
+
+    it('sibling', function () {
+        const matches = esquery(customNodes, 'CustomChild[name=two] ~ CustomChild', { visitorKeys });
+        assert.includeMembers(matches, [
+            customNodes.list[2],
+            customNodes.list[3],
+        ]);
+    });
+
+
+    it('sibling with fallback', function () {
+        const matches = esquery(customNodes, 'CustomChild[name=two] ~ CustomChild', {
+            fallback (node) {
+                return node.type === 'CustomRoot' ? ['list'] : node.type === 'CustomChild' ? ['sublist'] : [];
+            }
+        });
+        assert.includeMembers(matches, [
+            customNodes.list[2],
+            customNodes.list[3],
+        ]);
+    });
+
+    it('sibling with default fallback', function () {
+        const matches = esquery(customNodes, 'CustomChild[name=two] ~ CustomChild');
+        assert.includeMembers(matches, [
+            customNodes.list[2],
+            customNodes.list[3],
+        ]);
+    });
+
+    it('adjacent', function () {
+        const matches = esquery(customNodes, 'CustomChild[name=two] + CustomChild', { visitorKeys });
+        assert.includeMembers(matches, [
+            customNodes.list[2],
+        ]);
     });
 });


### PR DESCRIPTION
This PR supports custom visitor keys by adding options to `query`, `traverse`, `matches` and `match`.
Also, I changed to traverse using `Object.keys` when no option is specified. (Same as when using `'iteration'` for `estraverse.Visitor.fallback`.)

closes #111

You can set the following keys for the options:
- `visitorKeys` ... if specified, extend the properties of the nodes that traverse the node.
- `fallback` ... if specified, control the properties of traversing nodes when encountering unknown nodes. If not specified, use `Object.keys`. 

This option allows you to use queries such as `':nth-child'`, `':first-child'`, `' ~ '` and `' + '` in JSX and TypeScript ASTs.