### PR TITLE
Export getPath

### DIFF
--- a/esquery.js
+++ b/esquery.js
@@ -467,6 +467,7 @@ function query(ast, selector, options) {
     return match(ast, parse(selector), options);
 }
 
+query.getPath = getPath;
 query.parse = parse;
 query.match = match;
 query.traverse = traverse;


### PR DESCRIPTION
This is a useful utility function outside the library, and folks who are doing selectors (like me) will often want to do something like this without having to build up a whole selector. I think it's useful, in keeping with the goal of the library, and simple enough to make part of the public API.

I'm using esquery for the first time today and it's very useful! I just went to try to use `getPath` which I'd been looking for a simple implementation of anyway, and found it wasn't exported, so figured I'd give it a shot after not seeing similar requests in the issue history.