### PR TITLE
Allow naked binaryOp at the start of a `has` selector

### DIFF
--- a/esquery.js
+++ b/esquery.js
@@ -98,6 +98,9 @@ function matches(node, selector, ancestry, options) {
         case 'identifier':
             return selector.value.toLowerCase() === node.type.toLowerCase();
 
+        case 'exactNode':
+            return selector.value === node;
+
         case 'field': {
             const path = selector.name.split('.');
             const ancestor = ancestry[path.length - 1];
@@ -126,10 +129,15 @@ function matches(node, selector, ancestry, options) {
             const collector = [];
             for (const sel of selector.selectors) {
                 const a = [];
+                const selClone = { ...sel };
+                if (!selClone.left) {
+                    selClone.left = { type: 'exactNode', value: node };
+                }
+
                 estraverse.traverse(node, {
-                    enter (node, parent) {
+                    enter (innerNode, parent) {
                         if (parent != null) { a.unshift(parent); }
-                        if (matches(node, sel, a, options)) {
+                        if (matches(innerNode, sel, a, options)) {
                             collector.push(node);
                         }
                     },

--- a/grammar.pegjs
+++ b/grammar.pegjs
@@ -35,7 +35,7 @@ selectors = s:selector ss:(_ "," _ selector)* {
 }
 
 selector
-  = a:sequence ops:(binaryOp sequence)* {
+  = a:sequence? ops:(binaryOp sequence)* {
     return ops.reduce(function (memo, rhs) {
       return { type: rhs[0], left: memo, right: rhs[1] };
     }, a);

--- a/tests/queryHas.js
+++ b/tests/queryHas.js
@@ -28,4 +28,12 @@ describe('Parent selector query', function () {
         assert.equal(0, matches.length);
     });
 
+    it('binary op', function () {
+        const deepChildMatches = esquery(conditional, 'IfStatement:has(> Identifier[name="x"])');
+        assert.equal(0, deepChildMatches.length);
+
+        const shallowChildMatches = esquery(conditional, 'IfStatement:has(> LogicalExpression)');
+        assert.equal(1, shallowChildMatches.length);
+    });
+
 });


### PR DESCRIPTION
Fixes https://github.com/estools/esquery/issues/132, allowing users to write selectors with naked binary operators inside blocks, like `FunctionExpression:has(> [name="foo"])`.

This is achieved in two steps:
1. Update to the Peg.js grammar.
2. Handling the case of a missing left-hand selector inside a `has` block, by injecting a selector corresponding to the node which is then sub-traversed, using a new `exactNode` type.