### PR TITLE
Check that the node has a parent before matching a 'child' selector

### DIFF
--- a/esquery.js
+++ b/esquery.js
@@ -189,7 +189,7 @@ function generateMatcher(selector) {
             const left = getMatcher(selector.left);
             const right = getMatcher(selector.right);
             return (node, ancestry, options) => {
-                if (right(node, ancestry, options)) {
+                if (ancestry.length > 0 && right(node, ancestry, options)) {
                     return left(ancestry[0], ancestry.slice(1), options);
                 }
                 return false;

--- a/tests/queryComplex.js
+++ b/tests/queryComplex.js
@@ -38,4 +38,10 @@ describe('Complex selector query', function () {
             simpleProgram.body[2]
         ]);
     });
+
+    it('can not match a top level node', function () {
+        // Test fix for issue #135: half of a child selector matches a top-level node.
+        const matches = esquery(simpleProgram, 'NonExistingNodeType > *');
+        assert.includeMembers(matches, []);
+    });
 });

--- a/tests/queryComplex.js
+++ b/tests/queryComplex.js
@@ -42,6 +42,6 @@ describe('Complex selector query', function () {
     it('can not match a top level node', function () {
         // Test fix for issue #135: half of a child selector matches a top-level node.
         const matches = esquery(simpleProgram, 'NonExistingNodeType > *');
-        assert.includeMembers(matches, []);
+        assert.isEmpty(matches);
     });
 });


### PR DESCRIPTION
The child selector can try to match the left subselector to an undefined node when the right subselector matches to a top-level (i.e. parentless) node.

This pull request addresses that issue and adds a regression test.

This fixes the crash from issue #135 on my setup when running ESLint with [eslint-config-standard](https://github.com/standard/eslint-config-standard), as well as with the **@typescript-eslint/require-await** rule enabled. It might still be a good idea to consider merging #136 or #137 as well.