### PR TITLE
Allow for custom node type keys

### DIFF
--- a/esquery.js
+++ b/esquery.js
@@ -297,31 +297,33 @@ function generateMatcher(selector) {
         }
 
         case 'class': {
+
             const name = selector.name.toLowerCase();
             return (node, ancestry, options) => {
-                const nodeTypeKey = (options && options.nodeTypeKey) || 'type';
+
+                if (options && options.nodeTypeKey) return false;
 
                 switch(name){
                     case 'statement':
-                        if(node[nodeTypeKey].slice(-9) === 'Statement') return true;
+                        if(node.type.slice(-9) === 'Statement') return true;
                         // fallthrough: interface Declaration <: Statement { }
                     case 'declaration':
-                        return node[nodeTypeKey].slice(-11) === 'Declaration';
+                        return node.type.slice(-11) === 'Declaration';
                     case 'pattern':
-                        if(node[nodeTypeKey].slice(-7) === 'Pattern') return true;
+                        if(node.type.slice(-7) === 'Pattern') return true;
                         // fallthrough: interface Expression <: Node, Pattern { }
                     case 'expression':
-                        return node[nodeTypeKey].slice(-10) === 'Expression' ||
-                            node[nodeTypeKey].slice(-7) === 'Literal' ||
+                        return node.type.slice(-10) === 'Expression' ||
+                            node.type.slice(-7) === 'Literal' ||
                             (
-                                node[nodeTypeKey] === 'Identifier' &&
-                                (ancestry.length === 0 || ancestry[0][nodeTypeKey] !== 'MetaProperty')
+                                node.type === 'Identifier' &&
+                                (ancestry.length === 0 || ancestry[0].type !== 'MetaProperty')
                             ) ||
-                            node[nodeTypeKey] === 'MetaProperty';
+                            node.type === 'MetaProperty';
                     case 'function':
-                        return node[nodeTypeKey] === 'FunctionDeclaration' ||
-                            node[nodeTypeKey] === 'FunctionExpression' ||
-                            node[nodeTypeKey] === 'ArrowFunctionExpression';
+                        return node.type === 'FunctionDeclaration' ||
+                            node.type === 'FunctionExpression' ||
+                            node.type === 'ArrowFunctionExpression';
                 }
                 throw new Error(`Unknown class name: ${selector.name}`);
             };

--- a/tests/fixtures/customNodesWithKind.js
+++ b/tests/fixtures/customNodesWithKind.js
@@ -28,5 +28,11 @@ export default {
                 { kind: 'CustomGrandChild' },
             ],
         },
+        {
+            kind: 'CustomExpression'
+        },
+        {
+            kind: 'CustomStatement'
+        }
     ],
 };

--- a/tests/fixtures/customNodesWithKind.js
+++ b/tests/fixtures/customNodesWithKind.js
@@ -1,0 +1,32 @@
+export default {
+    kind: 'CustomRoot',
+    list: [
+        {
+            kind: 'CustomChild',
+            name: 'one',
+            sublist: [{ kind: 'CustomGrandChild' }],
+        },
+        {
+            kind: 'CustomChild',
+            name: 'two',
+            sublist: [],
+        },
+        {
+            kind: 'CustomChild',
+            name: 'three',
+            sublist: [
+                { kind: 'CustomGrandChild' },
+                { kind: 'CustomGrandChild' },
+            ],
+        },
+        {
+            kind: 'CustomChild',
+            name: 'four',
+            sublist: [
+                { kind: 'CustomGrandChild' },
+                { kind: 'CustomGrandChild' },
+                { kind: 'CustomGrandChild' },
+            ],
+        },
+    ],
+};

--- a/tests/matches.js
+++ b/tests/matches.js
@@ -174,7 +174,9 @@ describe('matches with custom AST and nodeTypeKey and custom visitor keys', func
             visitorKeys: {
                 CustomRoot: ['list'],
                 CustomChild: ['sublist'],
-                CustomGrandChild: []
+                CustomGrandChild: [],
+                CustomStatement: [],
+                CustomExpression: []
             },
             nodeTypeKey: 'kind'
         };

--- a/tests/matches.js
+++ b/tests/matches.js
@@ -3,6 +3,7 @@ import forLoop from './fixtures/forLoop.js';
 import simpleProgram from './fixtures/simpleProgram.js';
 import conditional from './fixtures/conditional.js';
 import customNodes from './fixtures/customNodes.js';
+import customNodesWithKind from './fixtures/customNodesWithKind.js';
 
 describe('matches', function () {
     it('falsey node', function () {
@@ -161,6 +162,39 @@ describe('matches with custom AST and custom visitor keys', function () {
                 customNodes.list[1],
                 selector,
                 [customNodes],
+                options
+            );
+        });
+    });
+});
+
+describe('matches with custom AST and nodeTypeKey and custom visitor keys', function () {
+    it('adjacent/sibling', function () {
+        const options = {
+            visitorKeys: {
+                CustomRoot: ['list'],
+                CustomChild: ['sublist'],
+                CustomGrandChild: []
+            },
+            nodeTypeKey: 'kind'
+        };
+
+        let selector = esquery.parse('CustomChild + CustomChild');
+        assert.doesNotThrow(() => {
+            esquery.matches(
+                customNodesWithKind.list[1],
+                selector,
+                [customNodesWithKind],
+                options
+            );
+        });
+
+        selector = esquery.parse('CustomChild ~ CustomChild');
+        assert.doesNotThrow(() => {
+            esquery.matches(
+                customNodesWithKind.list[1],
+                selector,
+                [customNodesWithKind],
                 options
             );
         });

--- a/tests/queryClass.js
+++ b/tests/queryClass.js
@@ -1,5 +1,6 @@
 import esquery from '../esquery.js';
 import ast from './fixtures/allClasses.js';
+import customNodesWithKind from './fixtures/customNodesWithKind.js';
 
 describe('Class query', function () {
 
@@ -65,5 +66,25 @@ describe('Class query', function () {
         ]);
         assert.equal(10, matches.length);
     });
+
+    it('custom nodes with :expression, :statement', function () {
+        const options = {
+            visitorKeys: {
+                CustomRoot: ['list'],
+                CustomChild: ['sublist'],
+                CustomGrandChild: [],
+                CustomStatement: [],
+                CustomExpression: []
+            },
+            nodeTypeKey: 'kind'
+        };
+
+        const matches1 = esquery(customNodesWithKind, ':expression', options);
+        assert.equal(0, matches1.length);
+
+        const matches2 = esquery(customNodesWithKind, ':statement', options);
+        assert.equal(0, matches2.length);
+    });
+
 
 });


### PR DESCRIPTION
In ESLint, we are looking at being able to support different formats of ASTs, and as such, we can't guarantee that the node type will always be in the `type` key. This patch allows a custom `nodeTypeKey` option to be passed in that will alter be used instead of `type` when specified.

I wasn't sure what kinds of tests you'd be looking for here, so I added one as an example, but please let me know if you'd like me to add others.