### PR TITLE
Broken selectors after exactNode

### DIFF
--- a/tests/queryHas.js
+++ b/tests/queryHas.js
@@ -35,4 +35,29 @@ describe('Parent selector query', function () {
         const shallowChildMatches = esquery(conditional, 'IfStatement:has(> LogicalExpression.test, > Identifier[name="x"])');
         assert.equal(1, shallowChildMatches.length);
     });
+
+    it('has(>BlockStatement)', function () {
+        const matches = esquery(conditional, 'IfStatement:has(>BlockStatement)');
+        assert.equal(3, matches.length);
+    });
+    it('has(BlockStatement>ExpressionStatement)', function () {
+        const matches = esquery(conditional, 'IfStatement:has(BlockStatement>ExpressionStatement)');
+        assert.equal(3, matches.length);
+    });
+    it('fails has(>BlockStatement>ExpressionStatement)', function () {
+        const matches = esquery(conditional, 'IfStatement:has(>BlockStatement>ExpressionStatement)');
+        assert.equal(3, matches.length);
+    });
+    it('workaround has(>BlockStatement:has(>ExpressionStatement))', function () {
+        const matches = esquery(conditional, 'IfStatement:has(>BlockStatement:has(>ExpressionStatement))');
+        assert.equal(3, matches.length);
+    });
+    it('fails has(>BlockStatement ExpressionStatement)', function () {
+        const matches = esquery(conditional, 'IfStatement:has(>BlockStatement ExpressionStatement)');
+        assert.equal(3, matches.length);
+    });
+    it('workaround has(>BlockStatement:has(ExpressionStatement))', function () {
+        const matches = esquery(conditional, 'IfStatement:has(>BlockStatement:has(ExpressionStatement))');
+        assert.equal(3, matches.length);
+    });
 });


### PR DESCRIPTION
Add more tests for https://github.com/estools/esquery/pull/145 that show these selectors do not work correctly
- `:has(>BlockStatement>ExpressionStatement)`
- `:has(>BlockStatement ExpressionStatement)`

but there are workarounds:
- `:has(>BlockStatement:has(>ExpressionStatement))`
- `:has(>BlockStatement:has(ExpressionStatement))`