### PR TITLE
Broken field selector on a descendant

### DIFF
--- a/tests/queryComplex.js
+++ b/tests/queryComplex.js
@@ -44,4 +44,23 @@ describe('Complex selector query', function () {
         const matches = esquery(simpleProgram, 'NonExistingNodeType > *');
         assert.isEmpty(matches);
     });
+
+    it('fails field on a descendant', function () {
+        const matches = esquery(simpleProgram, 'ExpressionStatement AssignmentExpression.left');
+        assert.deepEqual([
+            { name: 'x', type: 'Identifier' },
+            { name: 'y', type: 'Identifier' }
+        ], matches);
+
+        const matches2 = esquery(simpleProgram, 'ExpressionStatement AssignmentExpression.left Identifier[name="y"]');
+        assert.equal(1, matches2.length);
+    });
+
+    it('fails field should not apply to a parent of descendant', function () {
+        const matches = esquery(simpleProgram, 'ExpressionStatement AssignmentExpression > *.left');
+        assert.deepEqual([], matches);
+
+        const matches2 = esquery(simpleProgram, 'ExpressionStatement AssignmentExpression Identifier[name="y"].left');
+        assert.equal(0, matches2.length);
+    });
 });


### PR DESCRIPTION
Add more tests for field selector that show these selectors do not work correctly

`AssignmentExpression.left` currently behaves like `*.left > AssignmentExpression` so I have to use `AssignmentExpression > *.left` as workaround